### PR TITLE
Fix BDTopoGISLayers to make is use script as stream instead of as file,

### DIFF
--- a/prepare_data/src/main/groovy/org/orbisgis/bdtopo/BDTopoGISLayers.groovy
+++ b/prepare_data/src/main/groovy/org/orbisgis/bdtopo/BDTopoGISLayers.groovy
@@ -77,7 +77,7 @@ static IProcess importPreprocess(){
                 def input_hydro = 'INPUT_HYDRO_' + uuid
                 def input_veget = 'INPUT_VEGET_' + uuid
 
-                datasource.executeScript(this.class.getResource('importPreprocess.sql').toString(),
+                datasource.executeScript(getClass().getResourceAsStream('importPreprocess.sql'),
                         [ID_ZONE: idZone, DIST_BUFFER: distBuffer, EXPAND: expand, IRIS_GE: tableIrisName,
                          BATI_INDIFFERENCIE: tableBuildIndifName, BATI_INDUSTRIEL: tableBuildIndusName,
                          BATI_REMARQUABLE: tableBuildRemarqName, ROUTE: tableRoadName, TRONCON_VOIE_FERREE: tableRailName,
@@ -135,7 +135,7 @@ static IProcess initTypes(){
                 def railBDTopoType = 'RAIL_BD_TOPO_TYPE_' + uuid
                 def vegetBDTopoType = 'VEGET_BD_TOPO_TYPE_' + uuid
 
-                datasource.executeScript(this.class.getResource('typesMatching.sql').toString(),
+                datasource.executeScript(getClass().getResourceAsStream('typesMatching.sql'),
                         [BUILDING_ABSTRACT_USE_TYPE: buildingAbstractUseType,
                          ROAD_ABSTRACT_TYPE: roadAbstractType,
                          RAIL_ABSTRACT_TYPE: railAbstractType,

--- a/prepare_data/src/test/groovy/org/orbisgis/bdtopo/BDTopoGISLayersTest.groovy
+++ b/prepare_data/src/test/groovy/org/orbisgis/bdtopo/BDTopoGISLayersTest.groovy
@@ -1,20 +1,31 @@
 package org.orbisgis.bdtopo
 
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.orbisgis.PrepareData
 import org.orbisgis.datamanager.h2gis.H2GIS
 
 import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 class BDTopoGISLayersTest {
+
+    private final static String bdTopoDb = System.getProperty("user.home") + "/myh2gisbdtopodb.mv.db"
+
+    @BeforeAll
+    static void init(){
+        System.setProperty("test.bdtopo", Boolean.toString(new File(bdTopoDb).exists()))
+    }
 
     //TODO create a dummy dataset (from BD Topo) to run the test
 
     @Test
+    @EnabledIfSystemProperty(named = "test.bdtopo", matches = "true")
     void importPreprocessTest(){
         H2GIS h2GISDatabase = H2GIS.open("./target/myh2gisbdtopodb")
         def process = PrepareData.BDTopoGISLayers.importPreprocess()
-        process.execute([h2gis: h2GISDatabase, tableIrisName: 'IRIS_GE', tableBuildIndifName: 'BATI_INDIFFERENCIE',
+        assertTrue process.execute([datasource: h2GISDatabase, tableIrisName: 'IRIS_GE', tableBuildIndifName: 'BATI_INDIFFERENCIE',
                          tableBuildIndusName: 'BATI_INDUSTRIEL', tableBuildRemarqName: 'BATI_REMARQUABLE',
                          tableRoadName: 'ROUTE', tableRailName: 'TRONCON_VOIE_FERREE',
                          tableHydroName: 'SURFACE_EAU', tableVegetName: 'ZONE_VEGETATION',
@@ -31,10 +42,11 @@ class BDTopoGISLayersTest {
     }
 
     @Test
+    @EnabledIfSystemProperty(named = "test.bdtopo", matches = "true")
     void initTypes(){
         H2GIS h2GISDatabase = H2GIS.open("./target/myh2gisbdtopodb")
         def process = PrepareData.BDTopoGISLayers.initTypes()
-        process.execute([h2gis: h2GISDatabase, buildingAbstractUseType: 'BUILDING_ABSTRACT_USE_TYPE',
+        assertTrue process.execute([datasource: h2GISDatabase, buildingAbstractUseType: 'BUILDING_ABSTRACT_USE_TYPE',
                          roadAbstractType: 'ROAD_ABSTRACT_TYPE',  railAbstractType: 'RAIL_ABSTRACT_TYPE',
                          vegetAbstractType: 'VEGET_ABSTRACT_TYPE'])
         process.getResults().each {

--- a/prepare_data/src/test/groovy/org/orbisgis/common/AbstractTablesInitializationTest.groovy
+++ b/prepare_data/src/test/groovy/org/orbisgis/common/AbstractTablesInitializationTest.groovy
@@ -1,21 +1,32 @@
 package org.orbisgis.common
 
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.orbisgis.PrepareData
 import org.orbisgis.datamanager.h2gis.H2GIS
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 class AbstractTablesInitializationTest {
+
+    private final static String bdTopoDb = System.getProperty("user.home") + "/myh2gisbdtopodb.mv.db"
+
+    @BeforeAll
+    static void init(){
+        System.setProperty("test.bdtopo", Boolean.toString(new File(bdTopoDb).exists()))
+    }
 
     //TODO create a dummy dataset (from BD Topo) to run the test
 
     @Test
+    @EnabledIfSystemProperty(named = "test.bdtopo", matches = "true")
     void initParametersAbstract(){
         H2GIS h2GISDatabase = H2GIS.open("./target/myh2gisbdtopodb")
         def process = PrepareData.AbstractTablesInitialization.initParametersAbstract()
-        process.execute([datasource: h2GISDatabase])
+        assertTrue process.execute([datasource: h2GISDatabase])
         process.getResults().each {entry ->
             assertNotNull h2GISDatabase.getTable(entry.getValue())
         }

--- a/prepare_data/src/test/groovy/org/orbisgis/common/InputDataFormattingTest.groovy
+++ b/prepare_data/src/test/groovy/org/orbisgis/common/InputDataFormattingTest.groovy
@@ -1,20 +1,31 @@
 package org.orbisgis.common
 
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.orbisgis.PrepareData
 import org.orbisgis.datamanager.h2gis.H2GIS
 
 import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 class InputDataFormattingTest {
+
+    private final static String bdTopoDb = System.getProperty("user.home") + "/myh2gisbdtopodb.mv.db"
+
+    @BeforeAll
+    static void init(){
+        System.setProperty("test.bdtopo", Boolean.toString(new File(bdTopoDb).exists()))
+    }
 
     //TODO create a dummy dataset (from BD Topo) to run the test
 
     @Test
+    @EnabledIfSystemProperty(named = "test.bdtopo", matches = "true")
     void inputDataFormatting(){
-        H2GIS h2GISDatabase = H2GIS.open("./target/myh2gisbdtopodb")
+        H2GIS h2GISDatabase = H2GIS.open(bdTopoDb)
         def process = PrepareData.InputDataFormatting.inputDataFormatting()
-        process.execute([datasource: h2GISDatabase,
+        assertTrue process.execute([datasource: h2GISDatabase,
                          inputBuilding: 'INPUT_BUILDING', inputRoad: 'INPUT_ROAD', inputRail: 'INPUT_RAIL',
                          inputHydro: 'INPUT_HYDRO', inputVeget: 'INPUT_VEGET',
                          inputZone: 'ZONE', inputZoneNeighbors: 'ZONE_NEIGHBORS',


### PR DESCRIPTION
Fix BDTopoGISLayers to make is use script as stream instead of as file.
Fix test to run them only if a file name 'myh2gisbdtopodb.mv.db' is found in the user home folder.

@j3r3m1 the H2 database with the data for the test should be placed at `/home/YOUR_HOME_FOLDER/myh2gisbdtopodb.mv.db`.