### PR TITLE
Remove ZONE_NEIGHORS table as output and input for processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ jdk:
   - oraclejdk8
   - openjdk8
 
-script: mvn clean install
+script: mvn dependency:purge-local-repository clean install

--- a/preparedata/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/bdtopo/BDTopoGISLayers.groovy
+++ b/preparedata/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/bdtopo/BDTopoGISLayers.groovy
@@ -48,7 +48,6 @@ import org.orbisgis.processmanagerapi.IProcess
  * @return outputVegetName Table name in which the (ready to feed the GeoClimate model) vegetation areas are stored
  * @return outputImperviousName Table name in which the (ready to feed the GeoClimate model) impervious areas are stored
  * @return outputZoneName Table name in which the (ready to feed the GeoClimate model) zone is stored
- * @return outputZoneNeighborsName Table name in which the (ready to feed the GeoClimate model) neighboring zones are stored
  */
 IProcess importPreprocess(){
     return create({
@@ -66,8 +65,8 @@ IProcess importPreprocess(){
                 tableImperviousBuildSurfName: String,
                 tableImperviousRoadSurfName: String,
                 tableImperviousActivSurfName: String,
-                distBuffer: int,
-                expand: int,
+                distBuffer: 500,
+                expand: 1000,
                 idZone: String,
                 building_bd_topo_use_type: String,
                 building_abstract_use_type: String,
@@ -82,7 +81,7 @@ IProcess importPreprocess(){
                 veget_bd_topo_type: String,
                 veget_abstract_type: String
         outputs outputBuildingName: String, outputRoadName: String, outputRailName: String, outputHydroName: String,
-                outputVegetName   : String, outputImperviousName: String, outputZoneName: String, outputZoneNeighborsName: String
+                outputVegetName   : String, outputImperviousName: String, outputZoneName: String
         run { datasource, tableIrisName, tableBuildIndifName, tableBuildIndusName,
               tableBuildRemarqName, tableRoadName, tableRailName, tableHydroName, tableVegetName,
               tableImperviousSportName, tableImperviousBuildSurfName, tableImperviousRoadSurfName,
@@ -128,40 +127,39 @@ IProcess importPreprocess(){
             }
 
             def success = datasource.executeScript(getClass().getResourceAsStream('importPreprocess.sql'),
-                    [ID_ZONE                  : idZone, DIST_BUFFER: distBuffer,
-                     EXPAND                   : expand, IRIS_GE: tableIrisName,
-                     BATI_INDIFFERENCIE       : tableBuildIndifName, BATI_INDUSTRIEL: tableBuildIndusName,
-                     BATI_REMARQUABLE         : tableBuildRemarqName, ROUTE: tableRoadName,
-                     TRONCON_VOIE_FERREE      : tableRailName, SURFACE_EAU: tableHydroName,
-                     ZONE_VEGETATION          : tableVegetName,
+                    [ID_ZONE: idZone, DIST_BUFFER: distBuffer, EXPAND: expand,
+                     IRIS_GE: tableIrisName, BATI_INDIFFERENCIE: tableBuildIndifName,
+                     BATI_INDUSTRIEL: tableBuildIndusName, BATI_REMARQUABLE: tableBuildRemarqName,
+                     ROUTE: tableRoadName, TRONCON_VOIE_FERREE: tableRailName,
+                     SURFACE_EAU: tableHydroName, ZONE_VEGETATION: tableVegetName,
                      TERRAIN_SPORT: tableImperviousSportName, CONSTRUCTION_SURFACIQUE: tableImperviousBuildSurfName,
                      SURFACE_ROUTE: tableImperviousRoadSurfName, SURFACE_ACTIVITE: tableImperviousActivSurfName,
                      TMP_IRIS: tmpIris,
-                     ZONE                     : zone, ZONE_BUFFER: zoneBuffer,
-                     ZONE_EXTENDED            : zoneExtended, ZONE_NEIGHBORS: zoneNeighbors,
-                     BU_ZONE_INDIF            : bu_zone_indif, BU_ZONE_INDUS: bu_zone_indus,
-                     BU_ZONE_REMARQ           : bu_zone_remarq, INPUT_BUILDING: input_building,
-                     INPUT_ROAD               : input_road, INPUT_RAIL: input_rail,
-                     INPUT_HYDRO              : input_hydro, INPUT_VEGET: input_veget,
+                     ZONE: zone, ZONE_BUFFER: zoneBuffer, ZONE_EXTENDED: zoneExtended, ZONE_NEIGHBORS: zoneNeighbors,
+                     BU_ZONE_INDIF: bu_zone_indif, BU_ZONE_INDUS: bu_zone_indus, BU_ZONE_REMARQ: bu_zone_remarq,
+                     INPUT_BUILDING: input_building,
+                     INPUT_ROAD: input_road,
+                     INPUT_RAIL: input_rail,
+                     INPUT_HYDRO: input_hydro,
+                     INPUT_VEGET: input_veget,
                      TMP_IMPERV_CONSTRUCTION_SURFACIQUE : tmp_imperv_construction_surfacique, TMP_IMPERV_SURFACE_ROUTE : tmp_imperv_surface_route,
                      TMP_IMPERV_TERRAIN_SPORT : tmp_imperv_terrain_sport, TMP_IMPERV_SURFACE_ACTIVITE : tmp_imperv_surface_activite,
                      INPUT_IMPERVIOUS: input_impervious,
                      BUILDING_BD_TOPO_USE_TYPE: building_bd_topo_use_type, BUILDING_ABSTRACT_USE_TYPE: building_abstract_use_type,
-                     ROAD_BD_TOPO_TYPE        : road_bd_topo_type, ROAD_ABSTRACT_TYPE: road_abstract_type,
-                     ROAD_BD_TOPO_CROSSING    : road_bd_topo_crossing, ROAD_ABSTRACT_CROSSING: road_abstract_crossing,
-                     RAIL_BD_TOPO_TYPE        : rail_bd_topo_type, RAIL_ABSTRACT_TYPE: rail_abstract_type,
-                     RAIL_BD_TOPO_CROSSING    : rail_bd_topo_crossing, RAIL_ABSTRACT_CROSSING: rail_abstract_crossing,
-                     VEGET_BD_TOPO_TYPE       : veget_bd_topo_type, VEGET_ABSTRACT_TYPE: veget_abstract_type
+                     ROAD_BD_TOPO_TYPE: road_bd_topo_type, ROAD_ABSTRACT_TYPE: road_abstract_type,
+                     ROAD_BD_TOPO_CROSSING: road_bd_topo_crossing, ROAD_ABSTRACT_CROSSING: road_abstract_crossing,
+                     RAIL_BD_TOPO_TYPE: rail_bd_topo_type, RAIL_ABSTRACT_TYPE: rail_abstract_type,
+                     RAIL_BD_TOPO_CROSSING: rail_bd_topo_crossing, RAIL_ABSTRACT_CROSSING: rail_abstract_crossing,
+                     VEGET_BD_TOPO_TYPE: veget_bd_topo_type, VEGET_ABSTRACT_TYPE: veget_abstract_type
                     ])
             if(!success){
                 logger.error("Error occurred on the execution of the importPreprocess.sql script")
             }
             else{
                 logger.info('The importPreprocess.sql script has been executed')
-                [outputBuildingName: input_building, outputRoadName: input_road,
-                 outputRailName    : input_rail, outputHydroName: input_hydro,
-                 outputVegetName   : input_veget, outputImperviousName : input_impervious,
-                 outputZoneName    : zone, outputZoneNeighborsName: zoneNeighbors
+                [outputBuildingName: input_building, outputRoadName: input_road, outputRailName: input_rail,
+                 outputHydroName: input_hydro, outputVegetName: input_veget, outputImperviousName : input_impervious,
+                 outputZoneName: zone
                 ]
             }
         }

--- a/preparedata/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/common/InputDataFormatting.groovy
+++ b/preparedata/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/common/InputDataFormatting.groovy
@@ -18,11 +18,11 @@ import org.orbisgis.processmanagerapi.IProcess
  * @param inputVeget Table name in which the input vegetation areas are stored
  * @param inputImpervious Table name in which the input impervious areas are stored
  * @param inputZone Table name in which the input zone stored
- * @param inputZoneNeighbors Table name in which the neighboring zones are stored
  * @param hLevMin Minimum building level height
  * @param hLevMax Maximum building level height
  * @param hThresholdLev2 Threshold on the building height, used to determine the number of levels
  * @param idZone The Zone id
+ * @param expand The distance (expressed in meter) used to compute the extended area around the ZONE
  * @param buildingAbstractUseType The name of the table in which the abstract building's uses and types are stored
  * @param buildingAbstractParameters The name of the table in which the abstract building's parameters are stored
  * @param roadAbstractType The name of the table in which the abstract road's types are stored
@@ -55,8 +55,8 @@ IProcess inputDataFormatting(){
     return create({
         title 'Allows to control, format and enrich the input data in order to feed the GeoClimate model'
         inputs datasource: JdbcDataSource, inputBuilding: String, inputRoad: String, inputRail: String,
-                inputHydro: String, inputVeget: String, inputImpervious: String, inputZone: String, inputZoneNeighbors: String,
-                hLevMin: int, hLevMax: int, hThresholdLev2: int, idZone: String,
+                inputHydro: String, inputVeget: String, inputImpervious: String, inputZone: String,
+                hLevMin: 3, hLevMax: 15, hThresholdLev2: 10, expand: 1000, idZone: String,
                 buildingAbstractUseType: String, buildingAbstractParameters: String,
                 roadAbstractType: String, roadAbstractParameters: String, roadAbstractCrossing: String,
                 railAbstractType: String, railAbstractCrossing: String,
@@ -68,14 +68,15 @@ IProcess inputDataFormatting(){
                 outputVeget: String , outputVegetStatZone: String , outputVegetStatZoneExt: String ,
                 outputImpervious: String , outputZone: String
         run { JdbcDataSource datasource, inputBuilding, inputRoad, inputRail,
-              inputHydro, inputVeget, inputImpervious, inputZone, inputZoneNeighbors,
-              hLevMin = 3, hLevMax = 15, hThresholdLev2 = 10, idZone,
+              inputHydro, inputVeget, inputImpervious, inputZone,
+              hLevMin, hLevMax, hThresholdLev2, expand, idZone,
               buildingAbstractUseType, buildingAbstractParameters,
               roadAbstractType, roadAbstractParameters, roadAbstractCrossing,
               railAbstractType, railAbstractCrossing,
               vegetAbstractType, vegetAbstractParameters ->
             logger.info('Executing the inputDataFormatting.sql script')
             def uuid = UUID.randomUUID().toString().replaceAll('-', '_')
+            def zoneNeighbors = 'ZONE_NEIGHBORS_' + uuid
             def buZone = 'BU_ZONE_' + uuid
             def buildWithZone = 'BUILD_WITHIN_ZONE_' + uuid
             def buildOuterZone = 'BUILD_OUTER_ZONE_' + uuid
@@ -160,7 +161,7 @@ IProcess inputDataFormatting(){
             def success = datasource.executeScript(getClass().getResourceAsStream('inputDataFormatting.sql'),
                     [INPUT_BUILDING: inputBuilding, INPUT_ROAD: inputRoad, INPUT_RAIL: inputRail,
                      INPUT_HYDRO: inputHydro, INPUT_VEGET: inputVeget, INPUT_IMPERVIOUS: inputImpervious,
-                     ZONE: inputZone, ZONE_NEIGHBORS: inputZoneNeighbors,
+                     ZONE: inputZone, ZONE_NEIGHBORS: zoneNeighbors,
                      H_LEV_MIN: hLevMin, H_LEV_MAX: hLevMax, H_THRESHOLD_LEV2: hThresholdLev2, ID_ZONE: idZone,
                      BUILDING_ABSTRACT_USE_TYPE: buildingAbstractUseType, BUILDING_ABSTRACT_PARAMETERS: buildingAbstractParameters,
                      ROAD_ABSTRACT_TYPE: roadAbstractType, ROAD_ABSTRACT_PARAMETERS: roadAbstractParameters, ROAD_ABSTRACT_CROSSING: roadAbstractCrossing,

--- a/preparedata/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/osm/OSMGISLayers.groovy
+++ b/preparedata/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/osm/OSMGISLayers.groovy
@@ -12,10 +12,6 @@ import org.orbisgis.orbisprocess.geoclimate.preparedata.PrepareData
 import org.orbisgis.osm.OSMTools
 import org.orbisgis.processmanagerapi.IProcess
 
-import static org.orbisgis.osm.utils.OSMElement.NODE
-import static org.orbisgis.osm.utils.OSMElement.RELATION
-import static org.orbisgis.osm.utils.OSMElement.WAY
-
 @BaseScript PrepareData prepareData
 
 

--- a/preparedata/src/main/resources/org/orbisgis/orbisprocess/geoclimate/preparedata/bdtopo/importPreprocess.sql
+++ b/preparedata/src/main/resources/org/orbisgis/orbisprocess/geoclimate/preparedata/bdtopo/importPreprocess.sql
@@ -70,7 +70,7 @@ CREATE INDEX ON $ZONE_EXTENDED(the_geom) USING RTREE;
 
 -- Generation of the geometries of the neighbouring communes to the one studied
 DROP TABLE IF EXISTS $ZONE_NEIGHBORS;
-CREATE TABLE $ZONE_NEIGHBORS AS SELECT ST_UNION(ST_ACCUM(a.the_geom)) as the_geom, INSEE_COM as ID_ZONE FROM $IRIS_GE a, $ZONE_EXTENDED b WHERE a.the_geom && b.the_geom AND ST_INTERSECTS(a.the_geom, b.the_geom) GROUP BY a.INSEE_COM;
+CREATE TABLE $ZONE_NEIGHBORS (the_geom geometry, ID_ZONE varchar) AS SELECT the_geom, ID_ZONE FROM $ZONE UNION SELECT ST_DIFFERENCE(b.the_geom, a.the_geom) as the_geom, 'outside' FROM $ZONE a, $ZONE_EXTENDED b;
 CREATE INDEX ON $ZONE_NEIGHBORS(the_geom) USING RTREE;
 
 
@@ -160,4 +160,4 @@ DROP TABLE IF EXISTS $TMP_IMPERV_TERRAIN_SPORT, $TMP_IMPERV_CONSTRUCTION_SURFACI
 --------------------------------------------------------------------------------------------------
 -- Clear not needed tables
 --------------------------------------------------------------------------------------------------
-DROP TABLE $TMP_IRIS, $ZONE_BUFFER, $ZONE_EXTENDED, $BU_ZONE_INDIF, $BU_ZONE_INDUS, $BU_ZONE_REMARQ;
+DROP TABLE $ZONE_NEIGHBORS, $TMP_IRIS, $ZONE_BUFFER, $ZONE_EXTENDED, $BU_ZONE_INDIF, $BU_ZONE_INDUS, $BU_ZONE_REMARQ;

--- a/preparedata/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/bdtopo/BDTopoGISLayersTest.groovy
+++ b/preparedata/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/bdtopo/BDTopoGISLayersTest.groovy
@@ -266,24 +266,6 @@ class BDTopoGISLayersTest {
             assertEquals('56260', row.ID_ZONE)
         }
 
-        // Check if the ZONE_NEIGHBORS table has the correct number of columns and rows
-        tableName = process.getResults().outputZoneNeighborsName
-        assertNotNull(tableName)
-        table = h2GISDatabase.getTable(tableName)
-        assertNotNull(table)
-        assertEquals(2, table.columnCount)
-        assertEquals(11, table.rowCount)
-        // Check if the column types are correct
-        assertEquals('VARCHAR', table.getColumnsType('ID_ZONE'))
-        assertEquals('GEOMETRY', table.getColumnsType('THE_GEOM'))
-        // For each rows, check if the fields contains the expected values
-        table.eachRow { row ->
-            assertNotNull(row.THE_GEOM)
-            assertNotEquals('', row.THE_GEOM)
-            assertNotNull(row.ID_ZONE)
-            assertNotEquals('', row.ID_ZONE)
-        }
-
     }
 
     // Check whether the INPUT_IMPERVIOUS table is well produced, despite the absence of the SURFACE_ACTIVITE table

--- a/preparedata/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/common/InputDataFormattingTest.groovy
+++ b/preparedata/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/preparedata/common/InputDataFormattingTest.groovy
@@ -88,7 +88,7 @@ class InputDataFormattingTest {
                          inputBuilding: resultsImport.outputBuildingName, inputRoad: resultsImport.outputRoadName,
                          inputRail: resultsImport.outputRailName, inputHydro: resultsImport.outputHydroName,
                          inputVeget: resultsImport.outputVegetName, inputImpervious: resultsImport.outputImperviousName,
-                         inputZone: resultsImport.outputZoneName, inputZoneNeighbors: resultsImport.outputZoneNeighborsName,
+                         inputZone: resultsImport.outputZoneName, //inputZoneNeighbors: resultsImport.outputZoneNeighborsName,
 
                          hLevMin: 3, hLevMax: 15, hThresholdLev2: 10, idZone: '56260',
 
@@ -269,16 +269,16 @@ class InputDataFormattingTest {
         // ... with the building (INDIF) 'BATIMENT0000000290126764' which in Vannes (56260)
         assertEquals('56260', h2GISDatabase.firstRow("SELECT ID_ZONE FROM BUILDING " +
                 "WHERE ID_SOURCE='BATIMENT0000000290126764';")["ID_ZONE"])
-        // ... with the building (INDIF) 'BATIMENT0000000292059008' which in Saint-Avé (56206)
-        assertEquals('56206', h2GISDatabase.firstRow("SELECT ID_ZONE FROM BUILDING " +
+        // ... with the building (INDIF) 'BATIMENT0000000292059008' which in Saint-Avé (56206 - so 'outside' expected)
+        assertEquals('outside', h2GISDatabase.firstRow("SELECT ID_ZONE FROM BUILDING " +
                 "WHERE ID_SOURCE='BATIMENT0000000292059008';")["ID_ZONE"])
-        // ... with the building (INDIF) 'BATIMENT0000000291363628' which in Arradon (56003)
-        assertEquals('56003', h2GISDatabase.firstRow("SELECT ID_ZONE FROM BUILDING " +
+        // ... with the building (INDIF) 'BATIMENT0000000291363628' which in Arradon (56003 - so 'outside' expected)
+        assertEquals('outside', h2GISDatabase.firstRow("SELECT ID_ZONE FROM BUILDING " +
                 "WHERE ID_SOURCE='BATIMENT0000000291363628';")["ID_ZONE"])
 
         // Verifies that a building that straddles two communes is assigned to the right area
-        // ... with the building (INDIF) 'BATIMENT0000000290543985' which main part is in Séné (56243)
-        assertEquals('56243', h2GISDatabase.firstRow("SELECT ID_ZONE FROM BUILDING " +
+        // ... with the building (INDIF) 'BATIMENT0000000290543985' which main part is in Séné (56243 - so 'outside' expected)
+        assertEquals('outside', h2GISDatabase.firstRow("SELECT ID_ZONE FROM BUILDING " +
                 "WHERE ID_SOURCE='BATIMENT0000000290543985';")["ID_ZONE"])
         // ... with the building (INDIF) 'BATIMENT0000000087495765' which main part is in Vannes (56260)
         assertEquals('56260', h2GISDatabase.firstRow("SELECT ID_ZONE FROM BUILDING " +

--- a/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/PrepareBDTopo.groovy
+++ b/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/PrepareBDTopo.groovy
@@ -142,7 +142,7 @@ def prepareBDTopo() {
                                       inputVeget: preprocessTables.outputVegetName,
                                       inputImpervious: preprocessTables.outputImperviousName,
                                       inputZone: preprocessTables.outputZoneName,
-                                      inputZoneNeighbors: preprocessTables.outputZoneNeighborsName,
+                                      //inputZoneNeighbors: preprocessTables.outputZoneNeighborsName,
                                       hLevMin: hLevMin, hLevMax: hLevMax, hThresholdLev2: hThresholdLev2, idZone: idZone,
                                       buildingAbstractUseType: abstractTables.outputBuildingAbstractUseType,
                                       buildingAbstractParameters: abstractTables.outputBuildingAbstractParameters,
@@ -187,34 +187,6 @@ def prepareBDTopo() {
 
         }})
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 public static ProcessMapper createMapper(){
     def abstractTablesInit = AbstractTablesInitialization.initParametersAbstract()

--- a/processingchain/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/ChainProcessMainTest.groovy
+++ b/processingchain/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/ChainProcessMainTest.groovy
@@ -154,7 +154,7 @@ class ChainProcessMainTest {
         IProcess GeoIndicatorsCompute_i = ProcessingChain.Workflow.GeoIndicators()
         assertTrue GeoIndicatorsCompute_i.execute(datasource: datasource, zoneTable: zoneTableName,
                 buildingTable: buildingTableName, roadTable: roadTableName,
-                railTable: null, vegetationTable: vegetationTableName,
+                railTable: railTableName, vegetationTable: vegetationTableName,
                 hydrographicTable: hydrographicTableName, indicatorUse: ind_i,
                 svfSimplified: svfSimplified, prefixName: prefixName,
                 mapOfWeights: mapOfWeights)
@@ -195,7 +195,7 @@ class ChainProcessMainTest {
         IProcess GeoIndicatorsCompute_i = ProcessingChain.Workflow.GeoIndicators()
         assertTrue GeoIndicatorsCompute_i.execute(datasource: datasource, zoneTable: zoneTableName,
                 buildingTable: buildingTableName, roadTable: roadTableName,
-                railTable: null, vegetationTable: vegetationTableName,
+                railTable: railTableName, vegetationTable: vegetationTableName,
                 hydrographicTable: hydrographicTableName, indicatorUse: ind_i,
                 svfSimplified: svfSimplified, prefixName: prefixName,
                 mapOfWeights: mapOfWeights)
@@ -236,7 +236,7 @@ class ChainProcessMainTest {
         IProcess GeoIndicatorsCompute_i = ProcessingChain.Workflow.GeoIndicators()
         assertTrue GeoIndicatorsCompute_i.execute(datasource: datasource, zoneTable: zoneTableName,
                 buildingTable: buildingTableName, roadTable: roadTableName,
-                railTable: null, vegetationTable: vegetationTableName,
+                railTable: railTableName, vegetationTable: vegetationTableName,
                 hydrographicTable: hydrographicTableName, indicatorUse: ind_i,
                 svfSimplified: svfSimplified, prefixName: prefixName,
                 mapOfWeights: mapOfWeights)
@@ -277,7 +277,7 @@ class ChainProcessMainTest {
         IProcess GeoIndicatorsCompute_i = ProcessingChain.Workflow.GeoIndicators()
         assertTrue GeoIndicatorsCompute_i.execute(datasource: datasource, zoneTable: zoneTableName,
                 buildingTable: buildingTableName, roadTable: roadTableName,
-                railTable: null, vegetationTable: vegetationTableName,
+                railTable: railTableName, vegetationTable: vegetationTableName,
                 hydrographicTable: hydrographicTableName, indicatorUse: ind_i,
                 svfSimplified: svfSimplified, prefixName: prefixName,
                 mapOfWeights: mapOfWeights)
@@ -318,7 +318,7 @@ class ChainProcessMainTest {
         IProcess GeoIndicatorsCompute_i = ProcessingChain.Workflow.GeoIndicators()
         assertTrue GeoIndicatorsCompute_i.execute(datasource: datasource, zoneTable: zoneTableName,
                 buildingTable: buildingTableName, roadTable: roadTableName,
-                railTable: null, vegetationTable: vegetationTableName,
+                railTable: railTableName, vegetationTable: vegetationTableName,
                 hydrographicTable: hydrographicTableName, indicatorUse: ind_i,
                 svfSimplified: svfSimplified, prefixName: prefixName,
                 mapOfWeights: mapOfWeights)
@@ -359,7 +359,7 @@ class ChainProcessMainTest {
         IProcess GeoIndicatorsCompute_i = ProcessingChain.Workflow.GeoIndicators()
         assertTrue GeoIndicatorsCompute_i.execute(datasource: datasource, zoneTable: zoneTableName,
                 buildingTable: buildingTableName, roadTable: roadTableName,
-                railTable: null, vegetationTable: vegetationTableName,
+                railTable: railTableName, vegetationTable: vegetationTableName,
                 hydrographicTable: hydrographicTableName, indicatorUse: ind_i,
                 svfSimplified: svfSimplified, prefixName: prefixName,
                 mapOfWeights: mapOfWeights)


### PR DESCRIPTION
This PR aims at:
- convert the ID_ZONE type into varchar (it was stored in integer - mistake from my side)
- remove the `ZONE_NEIGHBORS` in the input model. 
   - only `ZONE` table is provided as an output to `BDTopoGISLayers.groovy` / input to `InputDataFormatting.groovy`
   - `ZONE_NEIGHBORS` table is only a temporary table, computed in each processes (`BDTopoGISLayers.groovy` and `InputDataFormatting.groovy`), using the `EXPAND` parameter (which has been added to the `InputDataFormatting` step)
   - buildings that are not in the studied zone have now an `ID_ZONE = 'outside'`
- the default value for the parameters (e.g `expand`, `hLevMin`, ...) are now defined in the `inputs` part of each processes


Note that the tests in `preparedata` and `processingchain` (`ProcessingChainBDTopoTest`) works well, but there is still a failure when executing `mvn clean install`

```
[ERROR] Failures: 
[ERROR]   ProcessingChainBDTopoTest>ChainProcessMainTest.GeoIndicatorsTest1:155 expected: <true> but was: <false>
[ERROR]   ProcessingChainBDTopoTest>ChainProcessMainTest.GeoIndicatorsTest2:196 expected: <true> but was: <false>
[ERROR]   ProcessingChainBDTopoTest>ChainProcessMainTest.GeoIndicatorsTest3:237 expected: <true> but was: <false>
[ERROR]   ProcessingChainBDTopoTest>ChainProcessMainTest.GeoIndicatorsTest4:278 expected: <true> but was: <false>
[ERROR]   ProcessingChainBDTopoTest>ChainProcessMainTest.GeoIndicatorsTest5:319 expected: <true> but was: <false>
[ERROR]   ProcessingChainBDTopoTest>ChainProcessMainTest.GeoIndicatorsTest6:360 expected: <true> but was: <false>
[INFO] 
[ERROR] Tests run: 31, Failures: 6, Errors: 0, Skipped: 2
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for geoclimate-parent 1.0.0-SNAPSHOT:
[INFO] 
[INFO] geoclimate-parent .................................. SUCCESS [  2.679 s]
[INFO] geoindicators ...................................... SUCCESS [ 25.645 s]
[INFO] preparedata ........................................ SUCCESS [04:31 min]
[INFO] processingchain .................................... FAILURE [36:30 min]
[INFO] geoclimate ......................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```