### PR TITLE
Syntax update

### DIFF
--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/AbstractTablesInitialization.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/AbstractTablesInitialization.groovy
@@ -1,7 +1,9 @@
 package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
 import groovy.transform.BaseScript
+import groovy.transform.Field
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
+import org.orbisgis.orbisdata.processmanager.api.IProcess
 import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
 
 @BaseScript GroovyProcessFactory pf
@@ -23,8 +25,7 @@ import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
  * @return outputVegetAbstractType The name of the table in which the abstract vegetation's types are stored
  * @return outputVegetAbstractParameters The name of the table in which the abstract vegetation's parameters are stored
  */
-
-create {
+@Field IProcess initParametersAbstract = create {
     title 'Initialize the abstract and parameter tables'
     id "initParametersAbstract"
     inputs datasource: JdbcDataSource

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/BDTopoGISLayers.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/BDTopoGISLayers.groovy
@@ -2,6 +2,7 @@
 package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
 import groovy.transform.BaseScript
+import groovy.transform.Field
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
 import org.orbisgis.orbisdata.processmanager.api.IProcess
 import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
@@ -48,7 +49,7 @@ import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
  * @return outputImperviousName Table name in which the (ready to feed the GeoClimate model) impervious areas are stored
  * @return outputZoneName Table name in which the (ready to feed the GeoClimate model) zone is stored
  */
-create {
+@Field IProcess importPreprocess = create {
     title 'Import and prepare BDTopo layers'
     id "importPreprocess"
     inputs 	datasource                  : JdbcDataSource,
@@ -247,7 +248,7 @@ create {
  * @return outputvegetBDTopoType The name of the table in which the BD Topo vegetation's types are stored
  */
 
-create {
+@Field IProcess initTypes = create {
     title 'Initialize the types tables for BD Topo and define the matching with the abstract types'
     id "initTypes"
     inputs datasource: JdbcDataSource, buildingAbstractUseType: String, roadAbstractType: String,

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/BDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/BDTopo_V2.groovy
@@ -1,6 +1,7 @@
 package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
 import groovy.transform.BaseScript
+import groovy.transform.Field
 import org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager
 
 
@@ -9,8 +10,14 @@ import org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager
  */
 @BaseScript GroovyProcessManager pm
 
-register([AbstractTablesInitialization,
-          BDTopoGISLayers,
-          InputDataFormatting,
-          PrepareBDTopo,
-          WorkflowBDTopo_V2])
+@Field static AbstractTablesInitialization abstractTablesInitialization
+@Field static BDTopoGISLayers bDTopoGISLayers
+@Field static InputDataFormatting inputDataFormatting
+@Field static PrepareBDTopo prepareBDTopo
+@Field static WorkflowBDTopo_V2 workflowBDTopo_V2
+
+abstractTablesInitialization = register(AbstractTablesInitialization)
+bDTopoGISLayers = register(BDTopoGISLayers)
+inputDataFormatting = register(InputDataFormatting)
+prepareBDTopo = register(PrepareBDTopo)
+workflowBDTopo_V2 = register(WorkflowBDTopo_V2)

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/InputDataFormatting.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/InputDataFormatting.groovy
@@ -1,6 +1,7 @@
 package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
 import groovy.transform.BaseScript
+import groovy.transform.Field
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
 import org.orbisgis.orbisdata.processmanager.api.IProcess
 import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
@@ -51,7 +52,7 @@ import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
  * @return outputZone Table name in which the (ready to be used in the GeoIndicators part) zone is stored
  */
 
-create {
+@Field IProcess formatData = create {
     title 'Allows to control, format and enrich the input data in order to feed the GeoClimate model'
     id "formatData"
     inputs datasource: JdbcDataSource, inputBuilding: String, inputRoad: String, inputRail: String,

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/PrepareBDTopo.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/PrepareBDTopo.groovy
@@ -1,7 +1,9 @@
 package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
 import groovy.transform.BaseScript
+import groovy.transform.Field
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
+import org.orbisgis.orbisdata.processmanager.api.IProcess
 import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
 import org.orbisgis.orbisdata.processmanager.process.ProcessMapper
 
@@ -43,7 +45,7 @@ import org.orbisgis.orbisdata.processmanager.process.ProcessMapper
  * @return outputStats List that stores the name of the statistic tables for each layer at different scales
  *
  */
-create {
+@Field IProcess prepareData = create {
     title "Extract and transform BD Topo data to Geoclimate model"
     id "prepareData"
     inputs datasource : JdbcDataSource,
@@ -76,7 +78,7 @@ create {
         }
 
         //Init model
-        def initParametersAbstract = processManager.AbstractTablesInitialization.initParametersAbstract
+        def initParametersAbstract = BDTopo_V2.abstractTablesInitialization.initParametersAbstract
         if (!initParametersAbstract(datasource: datasource)) {
             info "Cannot initialize the geoclimate data model."
             return
@@ -84,7 +86,7 @@ create {
         def abstractTables = initParametersAbstract.results
 
         //Init BD Topo parameters
-        def initTypes = processManager.BDTopoGISLayers.initTypes
+        def initTypes = BDTopo_V2.bDTopoGISLayers.initTypes
         if (!initTypes([datasource: datasource,
                         buildingAbstractUseType: abstractTables.outputBuildingAbstractUseType,
                         roadAbstractType: abstractTables.outputRoadAbstractType, roadAbstractCrossing: abstractTables.outputRoadAbstractCrossing,
@@ -96,7 +98,7 @@ create {
         def initTables = initTypes.results
 
         //Import preprocess
-        def importPreprocess = processManager.BDTopoGISLayers.importPreprocess
+        def importPreprocess = BDTopo_V2.bDTopoGISLayers.importPreprocess
         if (!importPreprocess([datasource: datasource,
                                tableIrisName: tableIrisName,
                                tableBuildIndifName: tableBuildIndifName,
@@ -129,7 +131,7 @@ create {
         def preprocessTables = importPreprocess.results
 
         // Input data formatting and statistics
-        def inputDataFormatting = processManager.InputDataFormatting.formatData
+        def inputDataFormatting = BDTopo_V2.inputDataFormatting.formatData
         if (!inputDataFormatting([datasource: datasource,
                                   inputBuilding: preprocessTables.outputBuildingName,
                                   inputRoad: preprocessTables.outputRoadName,

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
@@ -2,6 +2,7 @@ package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
 import groovy.json.JsonSlurper
 import groovy.transform.BaseScript
+import groovy.transform.Field
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 import org.orbisgis.orbisdata.datamanager.jdbc.postgis.POSTGIS
 import org.orbisgis.orbisdata.processmanager.api.IProcess
@@ -119,7 +120,7 @@ import org.orbisgis.orbisprocess.geoclimate.processingchain.ProcessingChain as P
  * Meteorological Society 93, no. 12 (2012): 1879-1900.
  *
  */
-create {
+@Field IProcess workflow = create {
     title "Create all geoindicators from BDTopo data"
     id "workflow"
     inputs configurationFile: String
@@ -888,7 +889,7 @@ def bdtopo_processing(def  h2gis_datasource, def processing_parameters,def id_zo
     int nbAreas = id_zones.size();
 
     //Let's run the BDTopo process for each insee code
-    def prepareBDTopoData = processManager.PrepareBDTopo.prepareData
+    def prepareBDTopoData = BDTopo_V2.prepareBDTopo.prepareData
     def geoIndicatorsComputed = false
     info "$nbAreas communes will be processed"
     id_zones.eachWithIndex { id_zone, index->

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
@@ -13,14 +13,13 @@ import org.slf4j.LoggerFactory
 
 import static org.junit.jupiter.api.Assertions.*
 
-class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
+class ProcessingChainBDTopo_V2Test extends ChainProcessAbstractTest{
 
     private static def PC = GroovyProcessManager.load(ProcessingChain)
-    private static def BDTopo = GroovyProcessManager.load(BDTopo_V2)
 
     private static communeToTest = "12174"
 
-    private static Logger logger = LoggerFactory.getLogger(ProcessingChainBDTopoTest.class)
+    private static Logger logger = LoggerFactory.getLogger(ProcessingChainBDTopo_V2Test.class)
     private static def h2db = "./target/myh2gisbdtopodb"
     private static def bdtopoFoldName = "sample_$communeToTest"
     private static def listTables = ["IRIS_GE", "BATI_INDIFFERENCIE", "BATI_INDUSTRIEL", "BATI_REMARQUABLE",
@@ -66,11 +65,11 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
     }
 
     @Test
-    void prepareBDTopoTest(){
+    void prepareBDTopo_V2Test(){
         def dbSuffixName = "_prepare"
         def inseeCode = communeToTest
         H2GIS h2GISDatabase = loadFiles(inseeCode, dbSuffixName)
-        def process = BDTopo.PrepareBDTopo.prepareData
+        def process = BDTopo_V2.prepareBDTopo.prepareData
         assertTrue process.execute([datasource: h2GISDatabase,
                                     tableIrisName: 'IRIS_GE', tableBuildIndifName: 'BATI_INDIFFERENCIE',
                                     tableBuildIndusName: 'BATI_INDUSTRIEL', tableBuildRemarqName: 'BATI_REMARQUABLE',
@@ -128,7 +127,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
     void bdtopoLczFromTestFiles() {
         def dbSuffixName = "_lcz"
         H2GIS datasource = loadFiles(communeToTest, dbSuffixName)
-        def process = BDTopo.PrepareBDTopo.prepareData
+        def process = BDTopo_V2.prepareBDTopo.prepareData
         assertTrue process.execute([datasource: datasource,
                                     tableIrisName: 'IRIS_GE', tableBuildIndifName: 'BATI_INDIFFERENCIE',
                                     tableBuildIndusName: 'BATI_INDUSTRIEL', tableBuildRemarqName: 'BATI_REMARQUABLE',
@@ -170,7 +169,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
     void bdtopoGeoIndicatorsFromTestFiles() {
         def dbSuffixName = "_geoIndicators"
         H2GIS h2GISDatabase = loadFiles(communeToTest, dbSuffixName)
-        def process = BDTopo.PrepareBDTopo.prepareData
+        def process = BDTopo_V2.prepareBDTopo.prepareData
         assertTrue process.execute([datasource: h2GISDatabase,
                                     tableIrisName: 'IRIS_GE', tableBuildIndifName: 'BATI_INDIFFERENCIE',
                                     tableBuildIndusName: 'BATI_INDUSTRIEL', tableBuildRemarqName: 'BATI_REMARQUABLE',
@@ -207,10 +206,10 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
-        IProcess processBDTopo = BDTopo.workflow
-        assertTrue(processBDTopo.execute(configurationFile: getClass().getResource("config/bdtopo_workflow_folderinput_folderoutput_id_zones.json").toURI()))mm
-        assertNotNull(processBDTopo.getResults().outputFolder)
-        def baseNamePathAndFileOut = processBDTopo.getResults().outputFolder + File.separator + "zone_" + communeToTest + "_"
+        IProcess processBDTopo_V2 = BDTopo_V2.workflowBDTopo_V2.workflow
+        assertTrue(processBDTopo_V2.execute(configurationFile: getClass().getResource("config/bdtopo_workflow_folderinput_folderoutput_id_zones.json").toURI()))mm
+        assertNotNull(processBDTopo_V2.getResults().outputFolder)
+        def baseNamePathAndFileOut = processBDTopo_V2.getResults().outputFolder + File.separator + "zone_" + communeToTest + "_"
         assertTrue(new File(baseNamePathAndFileOut + "rsu_indicators.geojson").exists())
         assertFalse(new File(baseNamePathAndFileOut + "rsu_lcz.geojson").exists())
         assertFalse(new File(baseNamePathAndFileOut + "block_indicators.geojson").exists())
@@ -219,12 +218,12 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
 
     @Test //Integration tests
     @Disabled
-    void testBDTopoConfigurationFile() {
+    void testBDTopo_V2ConfigurationFile() {
         def configFile = getClass().getResource("config/bdtopo_workflow_folderinput_folderoutput.json").toURI()
         //configFile =getClass().getResource("config/bdtopo_workflow_folderinput_folderoutput_id_zones.json").toURI()
         //configFile =getClass().getResource("config/bdtopo_workflow_folderinput_dboutput.json").toURI()
         //configFile =getClass().getResource("config/bdtopo_workflow_dbinput_dboutput.json").toURI()
-        IProcess process = BDTopo.WorkflowBDTopo_V2.workflow
+        IProcess process = BDTopo_V2.workflowBDTopo_V2.workflow
         assertTrue(process.execute(configurationFile: configFile))
     }
 
@@ -236,7 +235,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
         dirFile.delete()
         dirFile.mkdir()
         def bdTopoParameters = [
-                "description" :"Example of configuration file to run the BDTopo workflow and store the results in a folder",
+                "description" :"Example of configuration file to run the BDTopo_V2 workflow and store the results in a folder",
                 "geoclimatedb" : [
                         "path" : "${dirFile.absolutePath+File.separator+"bdtopo_workflow_db;AUTO_SERVER=TRUE"}",
                         "delete" :true
@@ -272,13 +271,13 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                          "hThresholdLev2": 10
                         ]
         ]
-        IProcess process = BDTopo.WorkflowBDTopo_V2.workflow
+        IProcess process = BDTopo_V2.workflowBDTopo_V2.workflow
         assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
     }
 
 
     @Test
-    void runBDTopoWorkflow(){
+    void runBDTopo_V2Workflow(){
         def dbSuffixName = "_workflow"
         def inseeCode = communeToTest
         def defaultParameters = [distance: 1000,indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
@@ -288,7 +287,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                                  "height_of_roughness_elements": 1, "terrain_roughness_length": 1],
                                  hLevMin : 3, hLevMax: 15, hThresholdLev2: 10]
         H2GIS h2GISDatabase = loadFiles(inseeCode, dbSuffixName)
-        def process = BDTopo.WorkflowBDTopo_V2.bdtopo_processing(h2GISDatabase, defaultParameters, inseeCode, null, null, null, null);
+        def process = BDTopo_V2.workflowBDTopo_V2.bdtopo_processing(h2GISDatabase, defaultParameters, inseeCode, null, null, null, null);
         checkSpatialTable(h2GISDatabase, "block_indicators")
         checkSpatialTable(h2GISDatabase, "building_indicators")
         checkSpatialTable(h2GISDatabase, "rsu_indicators")

--- a/geoclimate/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/Geoclimate.groovy
+++ b/geoclimate/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/Geoclimate.groovy
@@ -14,15 +14,15 @@ class Geoclimate {
 
     public static def Geoindicators = load(GI)
     public static def Osm = load(O)
-    public static def BDTopo = load(Topo)
+    public static Topo BDTopo_V2 = load(Topo)
     public static def ProcessingChain = load(PC)
 
-    public static class OSM{
+    static class OSM{
         public static def workflow = Geoclimate.Osm.WorkflowOSM.workflow
     }
 
-    public static class BDTOPO_V2{
-        public static def workflow = Geoclimate.BDTopo.WorkflowBDTopo_V2.workflow
+    static class BDTOPO_V2{
+        public static def workflow = Geoclimate.BDTopo_V2.WorkflowBDTopo_V2.workflow
     }
 
     /**
@@ -32,7 +32,7 @@ class Geoclimate {
      */
     static void setLogger(def logger){
         Osm.setLogger(logger)
-        BDTopo.setLogger(logger)
+        BDTopo_V2.setLogger(logger)
         ProcessingChain.setLogger(logger)
         Geoindicators.setLogger(logger)
     }

--- a/geoclimate/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/GeoclimateTest.groovy
+++ b/geoclimate/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/GeoclimateTest.groovy
@@ -10,5 +10,12 @@ class GeoclimateTest {
     void test() {
         assert Geoclimate.BDTOPO_V2.workflow
         assert Geoclimate.OSM.workflow
+
+        assert Geoclimate.BDTopo_V2.AbstractTablesInitialization.initParametersAbstract
+        assert Geoclimate.BDTopo_V2.BDTopoGISLayers.importPreprocess
+        assert Geoclimate.BDTopo_V2.BDTopoGISLayers.initTypes
+        assert Geoclimate.BDTopo_V2.InputDataFormatting.formatData
+        assert Geoclimate.BDTopo_V2.PrepareBDTopo.prepareData
+        assert Geoclimate.BDTopo_V2.WorkflowBDTopo_V2.workflow
     }
 }


### PR DESCRIPTION
An update for the geoclimate project syntax in order to make IDE autocompletion and navigation available again. More commit are comming, but first @ebocher and @j3r3m1 tell me what you think about the syntax. Before merge, a PR on OrbisData is comming.

The main change is the usage of the `Field` annotation which allow to use only script and no classes.

In the `ProcessManager` (here in the file `BDTopo_V2.groovy`), the declaration of a factory (like `AbstractTablesInitialization.groovy `) is done with two lines :
``` groovy
//Make the factory visible by the IDE
@Field static AbstractTablesInitialization abstractTablesInitialization
//Register the factory
abstractTablesInitialization = register(AbstractTablesInitialization)
```

In the `ProcessFactory`, a field with the process id as name is declared :
``` groovy
@Field IProcess prepareData = create { ... }
```

Now to call a process you can write :
``` groovy
//If only importing Geoclimate
def p = Geoclimate.BDTopo_V2.AbstractTablesInitialization.initParametersAbstract
//Or
def p = BDTopo.PrepareBDTopo.prepareData
```