### PR TITLE
Add new vegetation type and computation time pef

### DIFF
--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/Geoindicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/Geoindicators.groovy
@@ -33,4 +33,69 @@ abstract class Geoindicators extends GroovyProcessFactory {
     static def warn = { obj -> logger.warn(obj.toString()) }
     static def error = { obj -> logger.error(obj.toString()) }
 
+
+    /**
+     * Return a list of cached table names
+     * @return
+     */
+    static def isTableCacheEnable(){
+        return System.getProperty("GEOCLIMATE_CACHE")?true:false
+    }
+
+    /**
+     * Return a list of cached table names
+     * @return
+     */
+    static def enableTableCache(){
+        return System.setProperty("GEOCLIMATE_CACHE",true)
+    }
+
+    /**
+     * Return a list of cached table names
+     * @return
+     */
+    static def getCachedTableNames(){
+        return System.properties.findAll{it.key.startsWith("GEOCLIMATE_TABLE")}.collect{key, value -> value}
+    }
+
+    /**
+     * Remove from the list of table names the cached tables
+     * @return
+     */
+    static def removeAllCachedTableNames(def tableNames){
+        if(isTableCacheEnable()) {
+            tableNames.removeAll(getCachedTableNames())
+        }
+        return tableNames
+    }
+
+    /**
+     * Return the cached table name from its identifier
+     *
+     * @return
+     */
+    static def getCachedTableName(tableIdentifier){
+        return System.getProperty(tableIdentifier)
+    }
+
+    /**
+     * Add a table if the System properties to cache it
+     * The table is prefixed with the name GEOCLIMATE_
+     *
+     * @return
+     */
+    static void cacheTableName(baseTableName, outputTableName){
+        if(isTableCacheEnable()) {
+            System.setProperty("GEOCLIMATE_TABLE_" + baseTableName, outputTableName)
+        }
+    }
+
+    /**
+     * Clean the System properties that stores intermediate table names
+     * @return
+     */
+    static  void clearTablesCache(){
+        System.properties.removeAll {it.key.startsWith("GEOCLIMATE")}
+    }
+
 }

--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/RsuIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/RsuIndicators.groovy
@@ -1214,12 +1214,12 @@ return create {
     run { rsuTable, buildingTable, roadTable, waterTable, vegetationTable,
           imperviousTable, prefixName, datasource ->
 
-        def BASE_NAME = "SMALLEST_COMMUN_GEOMETRY"
+        def BASE_NAME = "RSU_SMALLEST_COMMUN_GEOMETRY"
 
         info "Executing RSU surface fractions computation"
 
         // The name of the outputTableName is constructed
-        def outputTableName = prefix prefixName, "rsu_" + BASE_NAME
+        def outputTableName = prefix prefixName, BASE_NAME
 
         if (rsuTable && datasource.hasTable(rsuTable)) {
             datasource."$rsuTable".id_rsu.createIndex()
@@ -1402,8 +1402,6 @@ return create {
         } else {
             error """Cannot compute any surface fraction statistics"""
         }
-
-
         [outputTableName: outputTableName]
     }
 }
@@ -1447,13 +1445,12 @@ IProcess surfaceFractions() {
         run { rsuTable, spatialRelationsTable, superpositions, priorities,
               prefixName, datasource ->
 
-            def BASE_NAME = "SURFACE_FRACTIONS"
+            def BASE_TABLE_NAME ="RSU_SURFACE_FRACTIONS"
             def LAYERS = ["road", "water", "high_vegetation", "low_vegetation", "impervious", "building"]
-
             info "Executing RSU surface fractions computation"
 
             // The name of the outputTableName is constructed
-            def outputTableName = prefix prefixName, "rsu_" + BASE_NAME
+            def outputTableName = postfix( BASE_TABLE_NAME)
 
             // Create the indexes on each of the input tables
             datasource."$rsuTable".id_rsu.createIndex()
@@ -1536,6 +1533,8 @@ IProcess surfaceFractions() {
                 }
             }
             datasource query + end_query
+            //Cache the table name to re-use it
+            cacheTableName(BASE_TABLE_NAME, outputTableName)
 
             [outputTableName: outputTableName]
         }

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModel.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModel.groovy
@@ -650,14 +650,15 @@ static float getHeightWall(height, r_height) {
  * @param hThresholdLev2 value
  * @return a map with the new values
  */
-/*  TODO : when all the values are already available, it might happen that this control modify them. For example, a tower of 32 levels is 92 meters high.
-     The control will put the value of heightRoof to 96 whereas it was 92. Do we accept it or are the real values considered as more reliable then the theoretical ones ?
- */
 static Map formatHeightsAndNbLevels(def heightWall, def heightRoof, def nbLevels, def h_lev_min,
                                    def h_lev_max,def hThresholdLev2, def nbLevFromType){
+    //Use the OSM values
+    if(heightWall!=0 && heightRoof!=0 && nbLevels!=0){
+        return [heightWall:heightWall, heightRoof:heightRoof, nbLevels:nbLevels, estimated:false]
+    }
     //Initialisation of heights and number of levels
     // Update height_wall
-    def boolean estimated =false
+    boolean estimated =false
     if(heightWall==0){
         if(heightRoof==0){
             if(nbLevels==0){
@@ -665,7 +666,7 @@ static Map formatHeightsAndNbLevels(def heightWall, def heightRoof, def nbLevels
                 estimated = true
             }
             else {
-                heightWall = h_lev_min*nbLevels
+                heightWall = h_lev_min*nbLevels+h_lev_min
             }
         }
         else {

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModel.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModel.groovy
@@ -20,7 +20,6 @@ import org.orbisgis.orbisdata.processmanager.api.IProcess
  * @param hThresholdLev2 Threshold on the building height, used to determine the number of levels
  * @param epsg EPSG code to apply
  * @param jsonFilename Name of the json formatted file containing the filtering parameters
- * @param estimateHeight Boolean indicating if the buildings heights have to be estimated or not
  * @return outputTableName The name of the final buildings table
  * @return outputEstimatedTableName The name of the table containing the state of estimation for each building
  */
@@ -28,23 +27,21 @@ IProcess formatBuildingLayer() {
     return create {
         title "Transform OSM buildings table into a table that matches the constraints of the GeoClimate input model"
         id "formatBuildingLayer"
-        inputs datasource: JdbcDataSource, inputTableName: String, inputZoneEnvelopeTableName: "", epsg: int, h_lev_min: 3, h_lev_max: 15, hThresholdLev2: 10, jsonFilename: "", estimateHeight: false, urbanAreasTableName : ""
+        inputs datasource: JdbcDataSource, inputTableName: String, inputZoneEnvelopeTableName: "", epsg: int, h_lev_min: 3, h_lev_max: 15, hThresholdLev2: 10, jsonFilename: "",  urbanAreasTableName : ""
         outputs outputTableName: String, outputEstimateTableName: String
-        run { JdbcDataSource datasource, inputTableName, inputZoneEnvelopeTableName, epsg, h_lev_min, h_lev_max, hThresholdLev2, jsonFilename, estimateHeight, urbanAreasTableName ->
+        run { JdbcDataSource datasource, inputTableName, inputZoneEnvelopeTableName, epsg, h_lev_min, h_lev_max, hThresholdLev2, jsonFilename, urbanAreasTableName ->
             def outputTableName = postfix "INPUT_BUILDING"
             info 'Formating building layer'
             outputTableName = "INPUT_BUILDING_${UUID.randomUUID().toString().replaceAll("-", "_")}"
-            def outputEstimateTableName = ""
-            if (estimateHeight) {
-                outputEstimateTableName = "EST_${outputTableName}"
-                datasource """
+            def outputEstimateTableName = "EST_${outputTableName}"
+            datasource """
                     DROP TABLE if exists ${outputEstimateTableName};
                     CREATE TABLE ${outputEstimateTableName} (
                         id_build INTEGER,
                         ID_SOURCE VARCHAR,
                         estimated boolean)
                 """
-            }
+
             datasource """ 
                 DROP TABLE if exists ${outputTableName};
                 CREATE TABLE ${outputTableName} (THE_GEOM GEOMETRY(POLYGON, $epsg), id_build INTEGER, ID_SOURCE VARCHAR, 
@@ -71,7 +68,7 @@ IProcess formatBuildingLayer() {
                         queryMapper += " , st_force2D(st_makevalid(a.the_geom)) as the_geom FROM $inputTableName as a where st_area(a.the_geom)>1"
                     }
                     def id_build=1;
-                    datasource.withBatch(1000) { stmt ->
+                    datasource.withBatch(2000) { stmt ->
                         datasource.eachRow(queryMapper) { row ->
                             String height = row.height
                             String roof_height = row.'roof:height'
@@ -114,14 +111,14 @@ IProcess formatBuildingLayer() {
                                                     '${use}',
                                                     ${zIndex})
                                             """.toString()
-                                            if (estimateHeight) {
-                                                stmt.addBatch """
+
+                                            stmt.addBatch """
                                                 INSERT INTO ${outputEstimateTableName} values(
                                                     $id_build, 
                                                     '${row.id}',
                                                     ${formatedHeight.estimated})
                                                 """.toString()
-                                            }
+
                                             id_build++
                                         }
                                     }

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
@@ -21,6 +21,7 @@ import org.orbisgis.orbisanalysis.osm.OSMTools
 
 import java.sql.Connection
 import java.sql.SQLException
+import java.text.SimpleDateFormat
 
 @BaseScript OSM_Utils osm_utils
 
@@ -417,12 +418,11 @@ IProcess osm_processing() {
                 outputFolder: "", ouputTableFiles: "", output_datasource: "", outputTableNames: "", outputSRID : String, downloadAllOSMData : true,deleteOutputData:true
         outputs outputMessage: String
         run { h2gis_datasource, processing_parameters, id_zones, outputFolder, ouputTableFiles, output_datasource, outputTableNames, outputSRID, downloadAllOSMData,deleteOutputData ->
-
-            // Temporary tables
+             // Temporary tables
             int nbAreas = id_zones.size();
             info "$nbAreas osm areas will be processed"
-            def geoIndicatorsComputed = false
             id_zones.eachWithIndex { id_zone, index ->
+                def start = System.currentTimeMillis();
                 //Extract the zone table and read its SRID
                 def zoneTableNames = extractOSMZone(h2gis_datasource, id_zone, processing_parameters)
                 if (zoneTableNames) {
@@ -460,127 +460,123 @@ IProcess osm_processing() {
                         IProcess createGISLayerProcess = OSM.createGISLayers
                         if (createGISLayerProcess.execute(datasource: h2gis_datasource, osmFilePath: extract.results.outputFilePath, epsg: srid)) {
                             def gisLayersResults = createGISLayerProcess.getResults()
-                                info "Formating OSM GIS layers"
-                                //Format urban areas
-                                IProcess format = OSM.formatUrbanAreas
-                                format.execute([
-                                        datasource                : h2gis_datasource,
-                                        inputTableName            : gisLayersResults.urbanAreasTableName,
-                                        inputZoneEnvelopeTableName: zoneEnvelopeTableName,
-                                        epsg                      : srid])
-                                def urbanAreasTable = format.results.outputTableName
+                            info "Formating OSM GIS layers"
+                            //Format urban areas
+                            IProcess format = OSM.formatUrbanAreas
+                            format.execute([
+                                    datasource                : h2gis_datasource,
+                                    inputTableName            : gisLayersResults.urbanAreasTableName,
+                                    inputZoneEnvelopeTableName: zoneEnvelopeTableName,
+                                    epsg                      : srid])
+                            def urbanAreasTable = format.results.outputTableName
 
-                                def estimateHeight = processing_parameters."estimateHeight"
-                                format = OSM.formatBuildingLayer
-                                format.execute([
-                                        datasource                : h2gis_datasource,
-                                        inputTableName            : gisLayersResults.buildingTableName,
-                                        inputZoneEnvelopeTableName: zoneEnvelopeTableName,
-                                        epsg                      : srid,
-                                        estimateHeight            : estimateHeight,
-                                        urbanAreasTableName : urbanAreasTable ])
+                            def estimateHeight = processing_parameters."estimateHeight"
+                            format = OSM.formatBuildingLayer
+                            format.execute([
+                                    datasource                : h2gis_datasource,
+                                    inputTableName            : gisLayersResults.buildingTableName,
+                                    inputZoneEnvelopeTableName: zoneEnvelopeTableName,
+                                    epsg                      : srid,
+                                    urbanAreasTableName       : urbanAreasTable])
 
-                                def buildingTableName = format.results.outputTableName
-                                def buildingEstimateTableName = format.results.outputEstimateTableName
+                            def buildingTableName = format.results.outputTableName
+                            def buildingEstimateTableName = format.results.outputEstimateTableName
 
-                                format = OSM.formatRoadLayer
-                                format.execute([
-                                        datasource                : h2gis_datasource,
-                                        inputTableName            : gisLayersResults.roadTableName,
-                                        inputZoneEnvelopeTableName: zoneEnvelopeTableName,
-                                        epsg                      : srid])
-                                def roadTableName = format.results.outputTableName
+                            format = OSM.formatRoadLayer
+                            format.execute([
+                                    datasource                : h2gis_datasource,
+                                    inputTableName            : gisLayersResults.roadTableName,
+                                    inputZoneEnvelopeTableName: zoneEnvelopeTableName,
+                                    epsg                      : srid])
+                            def roadTableName = format.results.outputTableName
 
 
-                                format = OSM.formatRailsLayer
-                                format.execute([
-                                        datasource                : h2gis_datasource,
-                                        inputTableName            : gisLayersResults.railTableName,
-                                        inputZoneEnvelopeTableName: zoneEnvelopeTableName,
-                                        epsg                      : srid])
-                                def railTableName = format.results.outputTableName
+                            format = OSM.formatRailsLayer
+                            format.execute([
+                                    datasource                : h2gis_datasource,
+                                    inputTableName            : gisLayersResults.railTableName,
+                                    inputZoneEnvelopeTableName: zoneEnvelopeTableName,
+                                    epsg                      : srid])
+                            def railTableName = format.results.outputTableName
 
-                                format = OSM.formatVegetationLayer
-                                format.execute([
-                                        datasource                : h2gis_datasource,
-                                        inputTableName            : gisLayersResults.vegetationTableName,
-                                        inputZoneEnvelopeTableName: zoneEnvelopeTableName,
-                                        epsg                      : srid])
-                                def vegetationTableName = format.results.outputTableName
+                            format = OSM.formatVegetationLayer
+                            format.execute([
+                                    datasource                : h2gis_datasource,
+                                    inputTableName            : gisLayersResults.vegetationTableName,
+                                    inputZoneEnvelopeTableName: zoneEnvelopeTableName,
+                                    epsg                      : srid])
+                            def vegetationTableName = format.results.outputTableName
 
-                                format = OSM.formatHydroLayer
-                                format.execute([
-                                        datasource                : h2gis_datasource,
-                                        inputTableName            : gisLayersResults.hydroTableName,
-                                        inputZoneEnvelopeTableName: zoneEnvelopeTableName,
-                                        epsg                      : srid])
-                                def hydrographicTableName = format.results.outputTableName
+                            format = OSM.formatHydroLayer
+                            format.execute([
+                                    datasource                : h2gis_datasource,
+                                    inputTableName            : gisLayersResults.hydroTableName,
+                                    inputZoneEnvelopeTableName: zoneEnvelopeTableName,
+                                    epsg                      : srid])
+                            def hydrographicTableName = format.results.outputTableName
 
-                                format = OSM.formatImperviousLayer
-                                format.execute([
-                                        datasource                : h2gis_datasource,
-                                        inputTableName            : gisLayersResults.imperviousTableName,
-                                        inputZoneEnvelopeTableName: zoneEnvelopeTableName,
-                                        epsg                      : srid])
-                                def imperviousTableName = format.results.outputTableName
+                            format = OSM.formatImperviousLayer
+                            format.execute([
+                                    datasource                : h2gis_datasource,
+                                    inputTableName            : gisLayersResults.imperviousTableName,
+                                    inputZoneEnvelopeTableName: zoneEnvelopeTableName,
+                                    epsg                      : srid])
+                            def imperviousTableName = format.results.outputTableName
 
-                                //Sea/Land mask
-                                format = OSM.formatSeaLandMask
-                                format.execute([
-                                        datasource : h2gis_datasource,
-                                        inputTableName: gisLayersResults.coastlineTableName,
-                                        inputZoneEnvelopeTableName : zoneEnvelopeTableName,
-                                        epsg: srid])
+                            //Sea/Land mask
+                            format = OSM.formatSeaLandMask
+                            format.execute([
+                                    datasource                : h2gis_datasource,
+                                    inputTableName            : gisLayersResults.coastlineTableName,
+                                    inputZoneEnvelopeTableName: zoneEnvelopeTableName,
+                                    epsg                      : srid])
 
-                                def seaLandMaskTableName = format.results.outputTableName
+                            def seaLandMaskTableName = format.results.outputTableName
 
-                                //Sea/Land mask
-                                format = OSM.mergeWaterAndSeaLandTables
-                                format.execute([
-                                        datasource : h2gis_datasource,
-                                        inputSeaLandTableName: seaLandMaskTableName ,inputWaterTableName : hydrographicTableName,
-                                        epsg: srid])
+                            //Sea/Land mask
+                            format = OSM.mergeWaterAndSeaLandTables
+                            format.execute([
+                                    datasource           : h2gis_datasource,
+                                    inputSeaLandTableName: seaLandMaskTableName, inputWaterTableName: hydrographicTableName,
+                                    epsg                 : srid])
 
-                                hydrographicTableName = format.results.outputTableName
+                            hydrographicTableName = format.results.outputTableName
 
-                                info "OSM GIS layers formated"
+                            info "OSM GIS layers formated"
 
-                                //Compute the indicators
-                                IProcess geoIndicators = ProcessingChain.GeoIndicatorsChain.computeAllGeoIndicators()
-                                if (!geoIndicators.execute(datasource: h2gis_datasource, zoneTable: zoneTableName,
-                                        buildingTable: buildingTableName, roadTable: roadTableName,
-                                        railTable: railTableName, vegetationTable: vegetationTableName,
-                                        hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName,
-                                        buildingEstimateTableName :buildingEstimateTableName,
-                                        surface_vegetation: processing_parameters.surface_vegetation,
-                                        surface_hydro: processing_parameters.surface_hydro,
-                                        snappingTolerance : processing_parameters.snappingTolerance,
-                                        indicatorUse: processing_parameters.indicatorUse,
-                                        svfSimplified: processing_parameters.svfSimplified,
-                                        prefixName: processing_parameters.prefixName,
-                                        mapOfWeights: processing_parameters.mapOfWeights,
-                                        urbanTypoModelName: "URBAN_TYPOLOGY_OSM_RF_2_0.model",
-                                        buildingHeightModelName : estimateHeight?"BUILDING_HEIGHT_OSM_RF_2_0.model":"")) {
-                                    error "Cannot build the geoindicators for the zone $id_zone"
-                                    geoIndicatorsComputed = false
-                                } else {
-                                    geoIndicatorsComputed = true
-                                    info "${id_zone} has been processed"
-                                }
-                                    def results = geoIndicators.getResults()
-                                    results.put("buildingTableName", buildingTableName)
-                                    results.put("roadTableName", roadTableName)
-                                    results.put("railTableName", railTableName)
-                                    results.put("hydrographicTableName", hydrographicTableName)
-                                    results.put("vegetationTableName", vegetationTableName)
-                                    results.put("imperviousTableName", imperviousTableName)
-                                    results.put("urbanAreasTableName", urbanAreasTable)
-                                    if (outputFolder && geoIndicatorsComputed && ouputTableFiles) {
-                                        saveOutputFiles(h2gis_datasource, id_zone, results, ouputTableFiles, outputFolder, "osm_", outputSRID, reproject, deleteOutputData)
-                                    }
-                                    if (output_datasource && geoIndicatorsComputed) {
-                                        saveTablesInDatabase(output_datasource, h2gis_datasource, outputTableNames, results, id_zone, srid, outputSRID, reproject)
-                                    }
+                            //Compute the indicators
+                            IProcess geoIndicators = ProcessingChain.GeoIndicatorsChain.computeAllGeoIndicators()
+                            if (!geoIndicators.execute(datasource: h2gis_datasource, zoneTable: zoneTableName,
+                                    buildingTable: buildingTableName, roadTable: roadTableName,
+                                    railTable: railTableName, vegetationTable: vegetationTableName,
+                                    hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName,
+                                    buildingEstimateTableName: buildingEstimateTableName,
+                                    surface_vegetation: processing_parameters.surface_vegetation,
+                                    surface_hydro: processing_parameters.surface_hydro,
+                                    snappingTolerance: processing_parameters.snappingTolerance,
+                                    indicatorUse: processing_parameters.indicatorUse,
+                                    svfSimplified: processing_parameters.svfSimplified,
+                                    prefixName: processing_parameters.prefixName,
+                                    mapOfWeights: processing_parameters.mapOfWeights,
+                                    urbanTypoModelName: "URBAN_TYPOLOGY_OSM_RF_2_0.model",
+                                    buildingHeightModelName: estimateHeight ? "BUILDING_HEIGHT_OSM_RF_2_0.model" : "")) {
+                                error "Cannot build the geoindicators for the zone $id_zone"
+                            } else {
+                                def results = geoIndicators.getResults()
+                            results.put("buildingTableName", buildingTableName)
+                            results.put("roadTableName", roadTableName)
+                            results.put("railTableName", railTableName)
+                            results.put("hydrographicTableName", hydrographicTableName)
+                            results.put("vegetationTableName", vegetationTableName)
+                            results.put("imperviousTableName", imperviousTableName)
+                            results.put("urbanAreasTableName", urbanAreasTable)
+                            if (outputFolder  && ouputTableFiles) {
+                                saveOutputFiles(h2gis_datasource, id_zone, results, ouputTableFiles, outputFolder, "osm_", outputSRID, reproject, deleteOutputData)
+                            }
+                            if (output_datasource) {
+                                saveTablesInDatabase(output_datasource, h2gis_datasource, outputTableNames, results, id_zone, srid, outputSRID, reproject)
+                            }
+                        }
 
                         } else {
                             error "Cannot load the OSM file ${extract.results.outputFilePath}"
@@ -597,7 +593,7 @@ IProcess osm_processing() {
 
                 info "Number of areas processed ${index + 1} on $nbAreas"
             }
-            return [outputMessage: "The OSM processing tasks have been done"]
+            return [outputMessage: "The OSM workflow has been executed"]
         }
     }
 }
@@ -955,6 +951,7 @@ def extractProcessingParameters(def processing_parameters){
  * @param ouputFolder the ouput folder
  * @param outputSRID srid code to reproject the result
  * @param reproject  true if the file must reprojected
+ * @param deleteOutputData delete the files if exist
  * @return
  */
 def saveOutputFiles(def h2gis_datasource, def id_zone, def results, def outputFiles, def ouputFolder, def subFolderName, def outputSRID, def reproject, def deleteOutputData){
@@ -1035,459 +1032,6 @@ def saveTableAsGeojson(def outputTable , def filePath,def h2gis_datasource,def o
         info "${outputTable} has been saved in ${filePath}."
     }
 }
-
-/**
- * Create the output tables in the output_datasource
- * @param output_datasource connexion to the output database
- * @param outputTableNames name of tables to store the geoclimate results
- * @param srid epsg code for the output tables
- * @return
- */
-def createOutputTables(def output_datasource, def outputTableNames, def srid){
-    //Output table names
-    def output_zones = outputTableNames.zones
-    def output_building_indicators = outputTableNames.building_indicators
-    def output_block_indicators = outputTableNames.block_indicators
-    def output_rsu_indicators = outputTableNames.rsu_indicators
-    def output_rsu_lcz = outputTableNames.rsu_lcz
-    def output_building = outputTableNames.building
-    def output_road = outputTableNames.road
-    def output_rail = outputTableNames.rail
-    def output_water = outputTableNames.water
-    def output_vegetation = outputTableNames.vegetation
-    def output_impervious = outputTableNames.impervious
-    def output_urban_areas = outputTableNames.urban_areas
-    def output_rsu_urban_typo_area = outputTableNames.rsu_urban_typo_area
-    def output_rsu_urban_typo_floor_area = outputTableNames.rsu_urban_typo_floor_area
-    def output_building_urban_typo= outputTableNames.building_urban_typo
-
-
-    if (output_block_indicators && !output_datasource.hasTable(output_block_indicators)){
-        output_datasource.execute """CREATE TABLE $output_block_indicators (
-        ID_BLOCK INTEGER, THE_GEOM GEOMETRY(GEOMETRY,$srid),
-        ID_RSU INTEGER, AREA DOUBLE PRECISION,
-        FLOOR_AREA DOUBLE PRECISION,VOLUME DOUBLE PRECISION,
-        HOLE_AREA_DENSITY DOUBLE PRECISION,
-        BUILDING_DIRECTION_EQUALITY DOUBLE PRECISION,
-        BUILDING_DIRECTION_UNIQUENESS DOUBLE PRECISION,
-        MAIN_BUILDING_DIRECTION VARCHAR,
-        CLOSINGNESS DOUBLE PRECISION, NET_COMPACTNESS DOUBLE PRECISION,
-        AVG_HEIGHT_ROOF_AREA_WEIGHTED DOUBLE PRECISION,
-        STD_HEIGHT_ROOF_AREA_WEIGHTED DOUBLE PRECISION,
-        ID_ZONE VARCHAR
-        );
-        CREATE INDEX IF NOT EXISTS idx_${output_block_indicators.replaceAll(".", "_")}_id_zone ON $output_block_indicators (ID_ZONE);"""
-    }
-    else if (output_block_indicators){
-        def outputTableSRID = output_datasource.getSpatialTable(output_block_indicators).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_block_indicators is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_block_indicators (ID_ZONE) VALUES('geoclimate');
-        DELETE from $output_block_indicators WHERE ID_ZONE= 'geoclimate';"""
-    }
-
-    if (output_building_indicators && !output_datasource.hasTable(output_building_indicators)){
-        output_datasource.execute """
-        CREATE TABLE $output_building_indicators (
-                THE_GEOM GEOMETRY(GEOMETRY,$srid),
-                ID_BUILD INTEGER,
-                ID_SOURCE VARCHAR,
-                HEIGHT_WALL INTEGER,
-                HEIGHT_ROOF INTEGER,
-                NB_LEV INTEGER,
-                TYPE VARCHAR,
-                MAIN_USE VARCHAR,
-                ZINDEX INTEGER,
-                ID_ZONE VARCHAR,
-                ID_BLOCK INTEGER,
-                ID_RSU INTEGER,
-                PERIMETER DOUBLE PRECISION,
-                AREA DOUBLE PRECISION,
-                VOLUME DOUBLE PRECISION,
-                FLOOR_AREA DOUBLE PRECISION,
-                TOTAL_FACADE_LENGTH DOUBLE PRECISION,
-                CONTIGUITY DOUBLE PRECISION,
-                COMMON_WALL_FRACTION DOUBLE PRECISION,
-                NUMBER_BUILDING_NEIGHBOR BIGINT,
-                AREA_CONCAVITY DOUBLE PRECISION,
-                FORM_FACTOR DOUBLE PRECISION,
-                RAW_COMPACTNESS DOUBLE PRECISION,
-                PERIMETER_CONVEXITY DOUBLE PRECISION,
-                MINIMUM_BUILDING_SPACING DOUBLE PRECISION,
-                ROAD_DISTANCE DOUBLE PRECISION,
-                LIKELIHOOD_LARGE_BUILDING DOUBLE PRECISION
-        );
-        CREATE INDEX IF NOT EXISTS idx_${output_building_indicators.replaceAll(".", "_")}_id_zone  ON $output_building_indicators (ID_ZONE);
-        """
-    }
-    else if (output_building_indicators){
-        def outputTableSRID = output_datasource.getSpatialTable(output_building_indicators).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_building_indicators is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_building_indicators (ID_ZONE) VALUES('geoclimate');
-        DELETE from $output_building_indicators WHERE ID_ZONE= 'geoclimate';"""
-    }
-
-    if (output_rsu_indicators && !output_datasource.hasTable(output_rsu_indicators)){
-        output_datasource.execute """
-    CREATE TABLE $output_rsu_indicators (
-    ID_RSU INTEGER,
-	THE_GEOM GEOMETRY(GEOMETRY,$srid),	
-	HIGH_VEGETATION_FRACTION DOUBLE PRECISION,
-	HIGH_VEGETATION_WATER_FRACTION DOUBLE PRECISION,
-	HIGH_VEGETATION_BUILDING_FRACTION DOUBLE PRECISION,
-	HIGH_VEGETATION_LOW_VEGETATION_FRACTION DOUBLE PRECISION,
-	HIGH_VEGETATION_ROAD_FRACTION DOUBLE PRECISION,
-	HIGH_VEGETATION_IMPERVIOUS_FRACTION DOUBLE PRECISION,
-	WATER_FRACTION DOUBLE PRECISION,
-	BUILDING_FRACTION DOUBLE PRECISION,
-	LOW_VEGETATION_FRACTION DOUBLE PRECISION,
-	ROAD_FRACTION DOUBLE PRECISION,
-	IMPERVIOUS_FRACTION DOUBLE PRECISION,
-	VEGETATION_FRACTION_URB DOUBLE PRECISION,
-	LOW_VEGETATION_FRACTION_URB DOUBLE PRECISION,
-	HIGH_VEGETATION_IMPERVIOUS_FRACTION_URB DOUBLE PRECISION,
-	HIGH_VEGETATION_PERVIOUS_FRACTION_URB DOUBLE PRECISION,
-	ROAD_FRACTION_URB DOUBLE PRECISION,
-	IMPERVIOUS_FRACTION_URB DOUBLE PRECISION,
-	BUILDING_FRACTION_LCZ DOUBLE PRECISION,
-	PERVIOUS_FRACTION_LCZ DOUBLE PRECISION,
-	HIGH_VEGETATION_FRACTION_LCZ DOUBLE PRECISION,
-	LOW_VEGETATION_FRACTION_LCZ DOUBLE PRECISION,
-	IMPERVIOUS_FRACTION_LCZ DOUBLE PRECISION,
-	WATER_FRACTION_LCZ DOUBLE PRECISION,
-	AREA DOUBLE PRECISION,
-	AVG_HEIGHT_ROOF_AREA_WEIGHTED DOUBLE PRECISION,
-	STD_HEIGHT_ROOF_AREA_WEIGHTED DOUBLE PRECISION,
-	ROAD_DIRECTION_DISTRIBUTION_H0_D0_30 DOUBLE PRECISION,
-	ROAD_DIRECTION_DISTRIBUTION_H0_D30_60 DOUBLE PRECISION,
-	ROAD_DIRECTION_DISTRIBUTION_H0_D60_90 DOUBLE PRECISION,
-	ROAD_DIRECTION_DISTRIBUTION_H0_D90_120 DOUBLE PRECISION,
-	ROAD_DIRECTION_DISTRIBUTION_H0_D120_150 DOUBLE PRECISION,
-	ROAD_DIRECTION_DISTRIBUTION_H0_D150_180 DOUBLE PRECISION,
-	GROUND_LINEAR_ROAD_DENSITY DOUBLE PRECISION,
-	NON_VERT_ROOF_AREA_H0_10 DOUBLE PRECISION,
-	NON_VERT_ROOF_AREA_H10_20 DOUBLE PRECISION,
-	NON_VERT_ROOF_AREA_H20_30 DOUBLE PRECISION,
-	NON_VERT_ROOF_AREA_H30_40 DOUBLE PRECISION,
-	NON_VERT_ROOF_AREA_H40_50 DOUBLE PRECISION,
-	NON_VERT_ROOF_AREA_H50 DOUBLE PRECISION,
-	VERT_ROOF_AREA_H0_10 DOUBLE PRECISION,
-	VERT_ROOF_AREA_H10_20 DOUBLE PRECISION,
-	VERT_ROOF_AREA_H20_30 DOUBLE PRECISION,
-	VERT_ROOF_AREA_H30_40 DOUBLE PRECISION,
-	VERT_ROOF_AREA_H40_50 DOUBLE PRECISION,
-	VERT_ROOF_AREA_H50 DOUBLE PRECISION,
-	VERT_ROOF_DENSITY DOUBLE PRECISION,
-	NON_VERT_ROOF_DENSITY DOUBLE PRECISION,
-	FREE_EXTERNAL_FACADE_DENSITY DOUBLE PRECISION,
-	GEOM_AVG_HEIGHT_ROOF DOUBLE PRECISION,
-	BUILDING_VOLUME_DENSITY DOUBLE PRECISION,
-	AVG_VOLUME DOUBLE PRECISION,
-	AVG_NUMBER_BUILDING_NEIGHBOR DOUBLE PRECISION,
-	BUILDING_FLOOR_AREA_DENSITY DOUBLE PRECISION,
-	AVG_MINIMUM_BUILDING_SPACING DOUBLE PRECISION,
-	BUILDING_NUMBER_DENSITY DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H0_10_D0_30 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H10_20_D0_30 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H20_30_D0_30 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H30_40_D0_30 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H40_50_D0_30 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H50_D0_30 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H0_10_D30_60 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H10_20_D30_60 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H20_30_D30_60 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H30_40_D30_60 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H40_50_D30_60 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H50_D30_60 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H0_10_D60_90 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H10_20_D60_90 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H20_30_D60_90 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H30_40_D60_90 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H40_50_D60_90 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H50_D60_90 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H0_10_D90_120 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H10_20_D90_120 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H20_30_D90_120 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H30_40_D90_120 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H40_50_D90_120 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H50_D90_120 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H0_10_D120_150 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H10_20_D120_150 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H20_30_D120_150 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H30_40_D120_150 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H40_50_D120_150 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H50_D120_150 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H0_10_D150_180 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H10_20_D150_180 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H20_30_D150_180 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H30_40_D150_180 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H40_50_D150_180 DOUBLE PRECISION,
-	PROJECTED_FACADE_AREA_DISTRIBUTION_H50_D150_180 DOUBLE PRECISION,
-	BUILDING_TOTAL_FRACTION DOUBLE PRECISION,
-	ASPECT_RATIO DOUBLE PRECISION,
-	GROUND_SKY_VIEW_FACTOR DOUBLE PRECISION,
-	EFFECTIVE_TERRAIN_ROUGHNESS_LENGTH DOUBLE PRECISION,
-	EFFECTIVE_TERRAIN_ROUGHNESS_CLASS INTEGER,
-	BUILDING_DIRECTION_EQUALITY DOUBLE PRECISION,
-	BUILDING_DIRECTION_UNIQUENESS DOUBLE PRECISION,
-	MAIN_BUILDING_DIRECTION VARCHAR,
-    ID_ZONE VARCHAR
-    );    
-        CREATE INDEX IF NOT EXISTS idx_${output_rsu_indicators.replaceAll(".", "_")}_id_zone ON $output_rsu_indicators (ID_ZONE);
-        """
-    } else if (output_rsu_indicators){
-        def outputTableSRID = output_datasource.getSpatialTable(output_rsu_indicators).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_rsu_indicators is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_rsu_indicators (ID_ZONE) VALUES('geoclimate');
-        DELETE from $output_rsu_indicators WHERE ID_ZONE= 'geoclimate';"""
-    }
-
-    if (output_rsu_lcz && !output_datasource.hasTable(output_rsu_lcz)){
-        output_datasource.execute """
-        CREATE TABLE $output_rsu_lcz(
-                ID_ZONE VARCHAR,
-                ID_RSU INTEGER,
-                THE_GEOM GEOMETRY(GEOMETRY,$srid),
-                LCZ1 INTEGER,
-                LCZ2 INTEGER,
-                MIN_DISTANCE DOUBLE PRECISION,
-                PSS DOUBLE PRECISION
-        );
-        CREATE INDEX IF NOT EXISTS idx_${output_rsu_lcz.replaceAll(".", "_")}_id_zone ON $output_rsu_lcz (ID_ZONE);
-        """
-    }else if (output_rsu_lcz){
-        def outputTableSRID = output_datasource.getSpatialTable(output_rsu_lcz).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_rsu_lcz is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_rsu_lcz (ID_ZONE) VALUES('geoclimate');
-        DELETE from $output_rsu_lcz WHERE ID_ZONE= 'geoclimate';"""
-    }
-
-    if (output_zones && !output_datasource.hasTable(output_zones)){
-        output_datasource.execute """
-        CREATE TABLE $output_zones(
-                ID_ZONE VARCHAR,
-                THE_GEOM GEOMETRY(GEOMETRY,$srid)
-        );
-        CREATE INDEX IF NOT EXISTS idx_${output_zones.replaceAll(".", "_")}_id_zone ON $output_zones (ID_ZONE);
-        """
-    }else if (output_zones){
-        def outputTableSRID = output_datasource.getSpatialTable(output_zones).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_zones is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_zones (ID_ZONE) VALUES('geoclimate');
-        DELETE from $output_zones WHERE ID_ZONE= 'geoclimate';"""
-    }
-
-    if (output_building && !output_datasource.hasTable(output_building)){
-        output_datasource.execute """CREATE TABLE $output_building  (THE_GEOM GEOMETRY(POLYGON, $srid), 
-        id_build serial, ID_SOURCE VARCHAR, HEIGHT_WALL FLOAT, HEIGHT_ROOF FLOAT,
-        NB_LEV INTEGER, TYPE VARCHAR, MAIN_USE VARCHAR, ZINDEX INTEGER);
-        CREATE INDEX IF NOT EXISTS idx_${output_building.replaceAll(".", "_")}_id_source ON $output_building (ID_SOURCE);"""
-    }
-    else if (output_building){
-        def outputTableSRID = output_datasource.getSpatialTable(output_building).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_building is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_building (ID_SOURCE) VALUES('geoclimate');
-        DELETE from $output_building WHERE ID_SOURCE= 'geoclimate';"""
-    }
-
-    if (output_road && !output_datasource.hasTable(output_road)){
-        output_datasource.execute """CREATE TABLE $output_road  (THE_GEOM GEOMETRY(GEOMETRY, $srid), 
-        id_road serial, ID_SOURCE VARCHAR, WIDTH FLOAT, TYPE VARCHAR, CROSSING VARCHAR(30),
-        SURFACE VARCHAR, SIDEWALK VARCHAR, ZINDEX INTEGER);
-        CREATE INDEX IF NOT EXISTS idx_${output_road.replaceAll(".", "_")}_id_source ON $output_road (ID_SOURCE);"""
-    }
-    else if (output_road){
-        def outputTableSRID = output_datasource.getSpatialTable(output_road).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_road is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_road (ID_SOURCE) VALUES('geoclimate');
-        DELETE from $output_road WHERE ID_SOURCE= 'geoclimate';"""
-    }
-
-    if (output_rail && !output_datasource.hasTable(output_rail)){
-        output_datasource.execute """CREATE TABLE $output_rail  (THE_GEOM GEOMETRY(GEOMETRY, $srid), 
-        id_rail serial,ID_SOURCE VARCHAR, TYPE VARCHAR,CROSSING VARCHAR(30), ZINDEX INTEGER);
-        CREATE INDEX IF NOT EXISTS idx_${output_rail.replaceAll(".", "_")}_id_source ON $output_rail (ID_SOURCE);"""
-    }
-    else if (output_rail){
-        def outputTableSRID = output_datasource.getSpatialTable(output_rail).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_rail is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_rail (ID_SOURCE) VALUES('geoclimate');
-        DELETE from $output_rail WHERE ID_SOURCE= 'geoclimate';"""
-    }
-
-    if (output_water && !output_datasource.hasTable(output_water)){
-        output_datasource.execute """CREATE TABLE $output_water  (THE_GEOM GEOMETRY(POLYGON, $srid), 
-        id_hydro serial, ID_SOURCE VARCHAR);
-        CREATE INDEX IF NOT EXISTS idx_${output_water.replaceAll(".", "_")}_id_source ON $output_water (ID_SOURCE);"""
-    }
-    else if (output_water){
-        def outputTableSRID = output_datasource.getSpatialTable(output_water).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_water is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_water (ID_SOURCE) VALUES('geoclimate');
-        DELETE from $output_water WHERE ID_SOURCE= 'geoclimate';"""
-    }
-
-    if (output_vegetation && !output_datasource.hasTable(output_vegetation)){
-        output_datasource.execute """CREATE TABLE $output_vegetation  (THE_GEOM GEOMETRY(POLYGON, $srid), 
-        id_veget serial, ID_SOURCE VARCHAR, TYPE VARCHAR, HEIGHT_CLASS VARCHAR(4));
-        CREATE INDEX IF NOT EXISTS idx_${output_vegetation.replaceAll(".", "_")}_id_source ON $output_vegetation (ID_SOURCE);"""
-    }
-    else if (output_vegetation){
-        def outputTableSRID = output_datasource.getSpatialTable(output_vegetation).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_vegetation is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_vegetation (ID_SOURCE) VALUES('geoclimate');
-        DELETE from $output_vegetation WHERE ID_SOURCE= 'geoclimate';"""
-    }
-
-    if (output_impervious && !output_datasource.hasTable(output_impervious)){
-        output_datasource.execute """CREATE TABLE $output_impervious  (THE_GEOM GEOMETRY(POLYGON, $srid), 
-        id_impervious serial, ID_SOURCE VARCHAR);
-        CREATE INDEX IF NOT EXISTS idx_${output_impervious.replaceAll(".", "_")}_id_source ON $output_impervious (ID_SOURCE);"""
-    }
-    else if (output_impervious){
-        def outputTableSRID = output_datasource.getSpatialTable(output_impervious).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_impervious is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_impervious (ID_SOURCE) VALUES('geoclimate');
-        DELETE from $output_impervious WHERE ID_SOURCE= 'geoclimate';"""
-    }
-
-    if (output_urban_areas && !output_datasource.hasTable(output_urban_areas)){
-        output_datasource.execute """CREATE TABLE $output_urban_areas  (THE_GEOM GEOMETRY(POLYGON, $srid), 
-        id_urban serial, ID_SOURCE VARCHAR, TYPE VARCHAR, MAIN_USE VARCHAR);
-        CREATE INDEX IF NOT EXISTS idx_${output_urban_areas.replaceAll(".", "_")}_id_source ON $output_urban_areas (ID_SOURCE);"""
-    }
-    else if (output_urban_areas){
-        def outputTableSRID = output_datasource.getSpatialTable(output_urban_areas).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_urban_areas is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_urban_areas (ID_SOURCE) VALUES('geoclimate');
-        DELETE from $output_urban_areas WHERE ID_SOURCE= 'geoclimate';"""
-    }
-
-    if (output_rsu_urban_typo_area && !output_datasource.hasTable(output_rsu_urban_typo_area)){
-        output_datasource.execute """CREATE TABLE $output_rsu_urban_typo_area (
-        ID_RSU INTEGER, THE_GEOM GEOMETRY(GEOMETRY,$srid),
-        TYPO_BA DOUBLE PRECISION,
-        TYPO_ICIO DOUBLE PRECISION,
-        TYPO_ID DOUBLE PRECISION,
-        TYPO_LOCAL DOUBLE PRECISION,
-        TYPO_PCIO DOUBLE PRECISION,
-        TYPO_PD DOUBLE PRECISION,
-        TYPO_PSC DOUBLE PRECISION,
-        UNIQUENESS_VALUE DOUBLE PRECISION,
-        TYPO_MAJ VARCHAR,
-        ID_ZONE VARCHAR
-        );
-         CREATE INDEX IF NOT EXISTS idx_${output_rsu_urban_typo_area.replaceAll(".", "_")}_id_zone ON $output_rsu_urban_typo_area (ID_ZONE);"""
-
-    }
-    else if (output_rsu_urban_typo_area){
-        def outputTableSRID = output_datasource.getSpatialTable(output_rsu_urban_typo_area).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_rsu_urban_typo_area is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_rsu_urban_typo_area (ID_ZONE) VALUES('geoclimate');
-        DELETE from $output_rsu_urban_typo_area WHERE ID_ZONE= 'geoclimate';"""
-    }
-
-    if (output_rsu_urban_typo_floor_area && !output_datasource.hasTable(output_rsu_urban_typo_floor_area)){
-        output_datasource.execute """CREATE TABLE $output_rsu_urban_typo_floor_area (
-        ID_RSU INTEGER, THE_GEOM GEOMETRY(GEOMETRY,$srid),
-        TYPO_BA DOUBLE PRECISION,
-        TYPO_ICIO DOUBLE PRECISION,
-        TYPO_ID DOUBLE PRECISION,
-        TYPO_LOCAL DOUBLE PRECISION,
-        TYPO_PCIO DOUBLE PRECISION,
-        TYPO_PD DOUBLE PRECISION,
-        TYPO_PSC DOUBLE PRECISION,
-        UNIQUENESS_VALUE DOUBLE PRECISION,
-        TYPO_MAJ VARCHAR,
-        ID_ZONE VARCHAR
-        );
-        CREATE INDEX IF NOT EXISTS idx_${output_rsu_urban_typo_floor_area.replaceAll(".", "_")}_id_zone ON $output_rsu_urban_typo_floor_area (ID_ZONE);"""
-    }
-    else if (output_rsu_urban_typo_floor_area){
-        def outputTableSRID = output_datasource.getSpatialTable(output_rsu_urban_typo_floor_area).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_rsu_urban_typo_floor_area is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_rsu_urban_typo_floor_area (ID_ZONE) VALUES('geoclimate');
-        DELETE from $output_rsu_urban_typo_floor_area WHERE ID_ZONE= 'geoclimate';"""
-    }
-
-    if (output_building_urban_typo && !output_datasource.hasTable(output_building_urban_typo)){
-        output_datasource.execute """CREATE TABLE $output_building_urban_typo (
-        ID_BUILD INTEGER,
-        ID_RSU INTEGER, THE_GEOM GEOMETRY(GEOMETRY,$srid),
-        I_TYPO VARCHAR,
-        ID_ZONE VARCHAR
-        );
-        CREATE INDEX IF NOT EXISTS idx_${output_building_urban_typo.replaceAll(".", "_")}_id_zone ON $output_building_urban_typo (ID_ZONE);"""
-    }
-    else if (output_building_urban_typo){
-        def outputTableSRID = output_datasource.getSpatialTable(output_building_urban_typo).srid
-        if(outputTableSRID!=srid){
-            error "The SRID of the output table ($outputTableSRID) $output_building_urban_typo is different than the srid of the result table ($srid)"
-            return null
-        }
-        //Test if we can write in the database
-        output_datasource.execute """INSERT INTO $output_building_urban_typo (ID_ZONE) VALUES('geoclimate');
-        DELETE from $output_building_urban_typo WHERE ID_ZONE= 'geoclimate';"""
-    }
-
-    return true
-}
-
 /**
  * Save the output tables in a database
  * @param output_datasource a connexion a database
@@ -1495,7 +1039,8 @@ def createOutputTables(def output_datasource, def outputTableNames, def srid){
  * @param outputTableNames name of the output tables
  * @param h2gis_tables name of H2GIS to save
  * @param id_zone id of the zone
- * @param outputSRID srid code to reproject the data
+ * @param outputSRID srid code to reproject the data *
+ * @param reproject the output table
  * @return
  */
 def saveTablesInDatabase(JdbcDataSource output_datasource, JdbcDataSource h2gis_datasource, def outputTableNames, def h2gis_tables, def id_zone,def inputSRID, def outputSRID, def reproject){

--- a/osm/src/main/resources/org/orbisgis/orbisprocess/geoclimate/osm/imperviousParams.json
+++ b/osm/src/main/resources/org/orbisgis/orbisprocess/geoclimate/osm/imperviousParams.json
@@ -12,7 +12,7 @@
     ],
     "leisure": ["pitch"],
     "railway": ["platform"],
-    "landuse": ["railway"]
+    "landuse": ["railway","construction"]
   },
   "columns": [
     "highway",

--- a/osm/src/main/resources/org/orbisgis/orbisprocess/geoclimate/osm/vegetParams.json
+++ b/osm/src/main/resources/org/orbisgis/orbisprocess/geoclimate/osm/vegetParams.json
@@ -55,20 +55,26 @@
                 "scrub"
             ]
         },
+        "grass": {
+            "natural": [
+                "grass"
+            ],
+            "landuse": [
+                "village_green"
+            ]
+        },
         "grassland": {
             "landcover": [
                 "grass",
                 "grassland"
             ],
             "natural": [
-                "grass",
                 "grassland"
             ],
             "vegetation": [
                 "grassland"
             ],
             "landuse": [
-                "grass",
                 "grassland"
             ]
         },
@@ -162,6 +168,7 @@
         "wood": "high",
         "forest": "high",
         "scrub": "low",
+        "grass": "low",
         "grassland": "low",
         "heath": "low",
         "park": "low",

--- a/osm/src/main/resources/org/orbisgis/orbisprocess/geoclimate/osm/vegetParams.json
+++ b/osm/src/main/resources/org/orbisgis/orbisprocess/geoclimate/osm/vegetParams.json
@@ -60,7 +60,8 @@
                 "grass"
             ],
             "landuse": [
-                "village_green"
+                "village_green",
+                "grass"
             ]
         },
         "grassland": {

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
@@ -374,11 +374,9 @@ class FormattingForAbstractModelTests {
         datasource    : h2GIS,
         inputTableName: extractData.results.buildingTableName,
         epsg          : epsg,
-        jsonFilename  : null,
-        estimateHeight : false])
+        jsonFilename  : null])
         assertEquals 1040, h2GIS.getTable(format.results.outputTableName).rowCount
-        assertEquals "", format.results.outputEstimateTableName
-
+        assertEquals 1040, h2GIS.getTable(format.results.outputEstimateTableName).rowCount
     }
 
 }

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
@@ -130,7 +130,7 @@ class FormattingForAbstractModelTests {
                 inputTableName: extractData.results.imperviousTableName,
                 epsg: epsg])
         assertNotNull h2GIS.getTable(format.results.outputTableName).save("./target/osm_impervious_formated.shp", true)
-        assertEquals 44, h2GIS.getTable(format.results.outputTableName).rowCount
+        assertEquals 45, h2GIS.getTable(format.results.outputTableName).rowCount
 
         //Sea/Land mask
         format = OSM.formatSeaLandMask

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
@@ -27,7 +27,7 @@ class FormattingForAbstractModelTests {
         assertEquals 44, h2GIS.getTable(extractData.results.railTableName).rowCount
         assertEquals 135, h2GIS.getTable(extractData.results.vegetationTableName).rowCount
         assertEquals 10, h2GIS.getTable(extractData.results.hydroTableName).rowCount
-        assertEquals 44, h2GIS.getTable(extractData.results.imperviousTableName).rowCount
+        assertEquals 45, h2GIS.getTable(extractData.results.imperviousTableName).rowCount
         assertEquals 6, h2GIS.getTable(extractData.results.urbanAreasTableName).rowCount
         assertEquals 0, h2GIS.getTable(extractData.results.coastlineTableName).rowCount
 
@@ -158,7 +158,7 @@ class FormattingForAbstractModelTests {
         //zoneToExtract = "Londres, Grand Londres, Angleterre, Royaume-Uni"
         //zoneToExtract="Vannes"
         //zoneToExtract="rezé"
-        zoneToExtract = "Le Havre"
+        zoneToExtract = "Brest"
 
         IProcess extractData = OSM.extractAndCreateGISLayers
         extractData.execute([
@@ -346,7 +346,7 @@ class FormattingForAbstractModelTests {
         assertEquals 44, h2GIS.getTable(extractData.results.railTableName).rowCount
         assertEquals 135, h2GIS.getTable(extractData.results.vegetationTableName).rowCount
         assertEquals 10, h2GIS.getTable(extractData.results.hydroTableName).rowCount
-        assertEquals 44, h2GIS.getTable(extractData.results.imperviousTableName).rowCount
+        assertEquals 45, h2GIS.getTable(extractData.results.imperviousTableName).rowCount
 
         //Buildings with estimation state
         IProcess format = OSM.formatBuildingLayer

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/OSMGISLayersTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/OSMGISLayersTests.groovy
@@ -20,10 +20,10 @@ class OSMGISLayersTests {
         IProcess process = OSM.extractAndCreateGISLayers
         process.execute([
                 datasource : h2GIS,
-                zoneToExtract: "Göteborgs Stad"])
+                zoneToExtract: "Brest"])
         process.getResults().each {it ->
             if(it.value!=null){
-                h2GIS.getTable(it.value).save("./target/${it.value}.geojson", true)
+                h2GIS.getTable(it.value).save("./target/${it.value}.shp", true)
             }
         }
     }
@@ -53,7 +53,7 @@ class OSMGISLayersTests {
         assertEquals 10, h2GIS.getTable(process.results.hydroTableName).rowCount
 
         //h2GIS.getTable(process.results.imperviousTableName).save("./target/osm_hydro.shp")
-        assertEquals 44, h2GIS.getTable(process.results.imperviousTableName).rowCount
+        assertEquals 45, h2GIS.getTable(process.results.imperviousTableName).rowCount
 
         //h2GIS.getTable(process.results.imperviousTableName).save("./target/osm_hydro.shp")
         assertEquals 6, h2GIS.getTable(process.results.urbanAreasTableName).rowCount

--- a/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
+++ b/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
@@ -1017,7 +1017,7 @@ IProcess computeAllGeoIndicators() {
     return create {
         title "Compute all geoindicators"
         id "computeAllGeoIndicators"
-        inputs datasource: JdbcDataSource, zoneTable: "", buildingTable: "",
+        inputs datasource: JdbcDataSource, zoneTable: String, buildingTable: String,
                 roadTable: "", railTable: "", vegetationTable: "",
                 hydrographicTable: "", imperviousTable: "",
                 buildingEstimateTableName :"",
@@ -1038,8 +1038,9 @@ IProcess computeAllGeoIndicators() {
               urbanTypoModelName, buildingHeightModelName ->
             //Estimate height
             if (buildingHeightModelName) {
+                def start = System.currentTimeMillis()
                 enableTableCache()
-                if(!buildingEstimateTableName){
+                if (!buildingEstimateTableName) {
                     error "To estimate the building height a table that contains the list of building to estimate must be provided"
                     return
                 }
@@ -1060,22 +1061,22 @@ IProcess computeAllGeoIndicators() {
                         }
                     }
                 } else {
-                    if(!FilenameUtils.isExtension(pathAndFileName, "model")){
+                    if (!FilenameUtils.isExtension(pathAndFileName, "model")) {
                         error "The extension of the model file must be .model"
                         return
                     }
                 }
-                IProcess geoIndicators =  computeGeoclimateIndicators()
+                IProcess geoIndicators = computeGeoclimateIndicators()
                 if (!geoIndicators.execute(datasource: datasource, zoneTable: zoneTable,
                         buildingTable: buildingTable,
                         roadTable: roadTable,
                         railTable: railTable, vegetationTable: vegetationTable,
                         hydrographicTable: hydrographicTable, imperviousTable: imperviousTable,
                         surface_vegetation: surface_vegetation, surface_hydro: surface_hydro,
-                        indicatorUse:["URBAN_TYPOLOGY"],
+                        indicatorUse: ["URBAN_TYPOLOGY"],
                         svfSimplified: true, prefixName: prefixName,
                         mapOfWeights: mapOfWeights,
-                        urbanTypoModelName:"")){
+                        urbanTypoModelName: "")) {
                     error "Cannot build the geoindicators to estimate the building height"
                     return
                 }
@@ -1098,6 +1099,7 @@ IProcess computeAllGeoIndicators() {
                                                         ON a.id_build=b.id_build
                                                     WHERE b.ESTIMATED = true AND a.ID_RSU IS NOT NULL;"""
 
+
                 info "Collect building indicators to estimate the height"
 
                 def applygatherScales = Geoindicators.GenericIndicators.gatherScales()
@@ -1115,12 +1117,12 @@ IProcess computeAllGeoIndicators() {
 
                 //Apply RF model
                 def applyRF = Geoindicators.TypologyClassification.applyRandomForestModel()
-                if(!applyRF.execute([
+                if (!applyRF.execute([
                         explicativeVariablesTableName: gatheredScales,
                         pathAndFileName              : buildingHeightModelName,
                         idName                       : "id_build",
                         prefixName                   : prefixName,
-                        datasource                   : datasource])){
+                        datasource                   : datasource])) {
                     error "Cannot apply the building height model $buildingHeightModelName"
                     return
                 }
@@ -1128,6 +1130,8 @@ IProcess computeAllGeoIndicators() {
                 //Update the abstract building table
                 info "Replace the input building table by the estimated height"
                 def buildEstimatedHeight = applyRF.results.outputTableName
+
+                def nbBuildingEstimated = datasource.firstRow("select count(*) as count from $buildEstimatedHeight").count
 
                 datasource.getTable(buildEstimatedHeight).id_build.createIndex()
 
@@ -1144,12 +1148,12 @@ IProcess computeAllGeoIndicators() {
 
                 //We must format only estimated buildings
                 //Apply format on the new abstract table
-                def  epsg =  datasource."$newEstimatedHeigthWithIndicators".srid;
+                def epsg = datasource."$newEstimatedHeigthWithIndicators".srid;
                 IProcess formatEstimatedBuilding = ProcessingChain.FormatingDataChain.formatEstimatedBuilding()
                 formatEstimatedBuilding.execute([
-                        datasource                : datasource,
-                        inputTableName            : newEstimatedHeigthWithIndicators,
-                        epsg : epsg])
+                        datasource    : datasource,
+                        inputTableName: newEstimatedHeigthWithIndicators,
+                        epsg          : epsg])
 
                 def newbuildingTableName = formatEstimatedBuilding.results.outputTableName
 
@@ -1160,7 +1164,7 @@ IProcess computeAllGeoIndicators() {
 
                 //We use the existing spatial units
                 def relationBlocks = results.outputTableBlockIndicators
-                def relationRSU  = results.outputTableRsuIndicators
+                def relationRSU = results.outputTableRsuIndicators
 
                 //The spatial relation tables RSU and BLOCK  must be filtered to keep only necessary columns
                 def rsuRelationFiltered = prefix prefixName, "RSU_RELATION_"
@@ -1181,8 +1185,8 @@ IProcess computeAllGeoIndicators() {
                 def COLUMN_ID_RSU = "id_rsu"
                 def COLUMN_ID_BUILD = "id_build"
                 def GEOMETRIC_COLUMN = "the_geom"
-                def CORRESPONDENCE_TAB_URB_TYPO = ["ba": 1,"bgh": 2,"icif": 3,"icio": 4,"id": 5,"local": 6,"pcif": 7,
-                                                   "pcio": 8,"pd": 9,"psc": 10]
+                def CORRESPONDENCE_TAB_URB_TYPO = ["ba"  : 1, "bgh": 2, "icif": 3, "icio": 4, "id": 5, "local": 6, "pcif": 7,
+                                                   "pcio": 8, "pd": 9, "psc": 10]
                 def nameColTypoMaj = "TYPO_MAJ"
 
                 // Output Lcz (and urbanTypo) table names are set to null in case LCZ indicators (and urban typo) are not calculated
@@ -1242,41 +1246,41 @@ IProcess computeAllGeoIndicators() {
                     info """ The LCZ classification is performed """
 
                     def lczIndicNames = ["GEOM_AVG_HEIGHT_ROOF"              : "HEIGHT_OF_ROUGHNESS_ELEMENTS",
-                                             "BUILDING_FRACTION_LCZ"             : "BUILDING_SURFACE_FRACTION",
-                                             "ASPECT_RATIO"                      : "ASPECT_RATIO",
-                                             "GROUND_SKY_VIEW_FACTOR"            : "SKY_VIEW_FACTOR",
-                                             "PERVIOUS_FRACTION_LCZ"             : "PERVIOUS_SURFACE_FRACTION",
-                                             "IMPERVIOUS_FRACTION_LCZ"           : "IMPERVIOUS_SURFACE_FRACTION",
-                                             "EFFECTIVE_TERRAIN_ROUGHNESS_LENGTH": "TERRAIN_ROUGHNESS_LENGTH"]
+                                         "BUILDING_FRACTION_LCZ"             : "BUILDING_SURFACE_FRACTION",
+                                         "ASPECT_RATIO"                      : "ASPECT_RATIO",
+                                         "GROUND_SKY_VIEW_FACTOR"            : "SKY_VIEW_FACTOR",
+                                         "PERVIOUS_FRACTION_LCZ"             : "PERVIOUS_SURFACE_FRACTION",
+                                         "IMPERVIOUS_FRACTION_LCZ"           : "IMPERVIOUS_SURFACE_FRACTION",
+                                         "EFFECTIVE_TERRAIN_ROUGHNESS_LENGTH": "TERRAIN_ROUGHNESS_LENGTH"]
 
-                        // Get into a new table the ID, geometry column and the 7 indicators defined by Stewart and Oke (2012)
-                        // for LCZ classification (rename the indicators with the real names)
-                        def queryReplaceNames = ""
-                        lczIndicNames.each { oldIndic, newIndic ->
-                            queryReplaceNames += "ALTER TABLE $lczIndicTable ALTER COLUMN $oldIndic RENAME TO $newIndic;"
-                        }
-                        datasource.execute """DROP TABLE IF EXISTS $lczIndicTable;
+                    // Get into a new table the ID, geometry column and the 7 indicators defined by Stewart and Oke (2012)
+                    // for LCZ classification (rename the indicators with the real names)
+                    def queryReplaceNames = ""
+                    lczIndicNames.each { oldIndic, newIndic ->
+                        queryReplaceNames += "ALTER TABLE $lczIndicTable ALTER COLUMN $oldIndic RENAME TO $newIndic;"
+                    }
+                    datasource.execute """DROP TABLE IF EXISTS $lczIndicTable;
                                 CREATE TABLE $lczIndicTable 
                                         AS SELECT $COLUMN_ID_RSU, $GEOMETRIC_COLUMN, ${lczIndicNames.keySet().join(",")} 
                                         FROM ${computeRSUIndicators.results.outputTableName};
                                 $queryReplaceNames"""
 
-                        datasource."$lczIndicTable".reload()
+                    datasource."$lczIndicTable".reload()
 
-                        // The classification algorithm is called
-                        def classifyLCZ = Geoindicators.TypologyClassification.identifyLczType()
-                        if (!classifyLCZ([rsuLczIndicators : lczIndicTable,
-                                          rsuAllIndicators : computeRSUIndicators.results.outputTableName,
-                                          normalisationType: "AVG",
-                                          mapOfWeights     : mapOfWeights,
-                                          prefixName       : prefixName,
-                                          datasource       : datasource,
-                                          prefixName       : prefixName])) {
-                            info "Cannot compute the LCZ classification."
-                            return
-                        }
-                        rsuLcz = classifyLCZ.results.outputTableName
-                        datasource.execute "DROP TABLE IF EXISTS $lczIndicTable"
+                    // The classification algorithm is called
+                    def classifyLCZ = Geoindicators.TypologyClassification.identifyLczType()
+                    if (!classifyLCZ([rsuLczIndicators : lczIndicTable,
+                                      rsuAllIndicators : computeRSUIndicators.results.outputTableName,
+                                      normalisationType: "AVG",
+                                      mapOfWeights     : mapOfWeights,
+                                      prefixName       : prefixName,
+                                      datasource       : datasource,
+                                      prefixName       : prefixName])) {
+                        info "Cannot compute the LCZ classification."
+                        return
+                    }
+                    rsuLcz = classifyLCZ.results.outputTableName
+                    datasource.execute "DROP TABLE IF EXISTS $lczIndicTable"
 
                 }
                 // If the URBAN_TYPOLOGY indicators should be calculated, we only affect a URBAN typo class
@@ -1295,12 +1299,12 @@ IProcess computeAllGeoIndicators() {
                     gatheredScales = applygatherScales.results.outputTableName
 
                     applyRF = Geoindicators.TypologyClassification.applyRandomForestModel()
-                    if(!applyRF.execute([
+                    if (!applyRF.execute([
                             explicativeVariablesTableName: gatheredScales,
                             pathAndFileName              : urbanTypoModelName,
                             idName                       : COLUMN_ID_BUILD,
                             prefixName                   : prefixName,
-                            datasource                   : datasource])){
+                            datasource                   : datasource])) {
                         error "Cannot apply the urban typology model $urbanTypoModelName"
                         return
                     }
@@ -1308,26 +1312,26 @@ IProcess computeAllGeoIndicators() {
 
                     // Creation of a list which contains all types of the urban typology (in their string version)
                     def urbTypoCorrespondenceTabInverted = [:]
-                    CORRESPONDENCE_TAB_URB_TYPO.each{fin, ini->
-                        urbTypoCorrespondenceTabInverted[ini]=fin
+                    CORRESPONDENCE_TAB_URB_TYPO.each { fin, ini ->
+                        urbTypoCorrespondenceTabInverted[ini] = fin
                     }
                     datasource."$urbanTypoBuild".I_TYPO.createIndex()
                     def queryDistinct = """SELECT DISTINCT I_TYPO AS I_TYPO FROM $urbanTypoBuild"""
                     def mapTypos = datasource.rows(queryDistinct)
                     def listTypos = []
-                    mapTypos.each{
+                    mapTypos.each {
                         listTypos.add(urbTypoCorrespondenceTabInverted[it.I_TYPO])
                     }
 
                     // Join the geometry field to the building typology table and replace integer by string values
                     def queryCaseWhenReplace = ""
                     def endCaseWhen = ""
-                    urbTypoCorrespondenceTabInverted.each{ini, fin ->
+                    urbTypoCorrespondenceTabInverted.each { ini, fin ->
                         queryCaseWhenReplace += "CASE WHEN b.I_TYPO=$ini THEN '$fin' ELSE "
                         endCaseWhen += " END"
                     }
                     queryCaseWhenReplace = queryCaseWhenReplace + " 'unknown' " + endCaseWhen
-                    urbanTypoBuilding = prefix  prefixName, "URBAN_TYPO_BUILDING"
+                    urbanTypoBuilding = prefix prefixName, "URBAN_TYPO_BUILDING"
                     datasource."$urbanTypoBuild"."$COLUMN_ID_BUILD".createIndex()
                     datasource."$buildingIndicators"."$COLUMN_ID_BUILD".createIndex()
                     datasource """  DROP TABLE IF EXISTS $urbanTypoBuilding;
@@ -1340,11 +1344,11 @@ IProcess computeAllGeoIndicators() {
 
                     // Create a distribution table (for each RSU, contains the % area OR floor area of each urban typo)
                     def queryCasewhen = [:]
-                    queryCasewhen["AREA"]=""
-                    queryCasewhen["FLOOR_AREA"]=""
-                    queryCasewhen.keySet().each{ind ->
+                    queryCasewhen["AREA"] = ""
+                    queryCasewhen["FLOOR_AREA"] = ""
+                    queryCasewhen.keySet().each { ind ->
                         def querySum = ""
-                        listTypos.each{typoCol ->
+                        listTypos.each { typoCol ->
                             queryCasewhen[ind] += """ SUM(CASE WHEN a.I_TYPO='$typoCol' THEN b.$ind ELSE 0 END) AS TYPO_$typoCol,"""
                             querySum = querySum + " COALESCE(b.TYPO_${typoCol}/(b.TYPO_${listTypos.join("+b.TYPO_")}), 0) AS TYPO_$typoCol,"
                         }
@@ -1401,8 +1405,7 @@ IProcess computeAllGeoIndicators() {
                     }
                     // Drop temporary tables
                     datasource """DROP TABLE IF EXISTS $urbanTypoBuild, $gatheredScales, $distribNotPercent, TEMPO_DISTRIB"""
-                }
-                else{
+                } else {
                     urbanTypoArea = null
                     urbanTypoFloorArea = null
                     urbanTypoBuilding = null
@@ -1411,9 +1414,36 @@ IProcess computeAllGeoIndicators() {
                 datasource.execute "DROP TABLE IF EXISTS $rsuLczWithoutGeom;"
                 //Drop all cached tables
                 def cachedTableNames = getCachedTableNames()
-                if(cachedTableNames) {
+                if (cachedTableNames) {
                     datasource.execute "DROP TABLE IF EXISTS ${cachedTableNames.join(",")}"
                 }
+
+                //Populate reporting
+                def nbBuilding = datasource.firstRow("select count(*) as count from ${computeBuildingsIndicators.getResults().outputTableName} WHERE ID_RSU IS NOT NULL").count
+
+                def nbBlock = 0
+                if (blockIndicators) {
+                 nbBlock = datasource.firstRow("select count(*) as count from ${blockIndicators}").count
+                }
+                def nbRSU = datasource.firstRow("select count(*) as count from ${computeRSUIndicators.getResults().outputTableName}").count
+                //Alter the zone table to add statics
+                datasource.execute"""ALTER TABLE ${zoneTable} ADD COLUMN (
+                NB_BUILDING INTEGER,
+                NB_ESTIMATED_BUILDING INTEGER,
+                NB_BLOCK INTEGER,
+                NB_RSU INTEGER,
+                COMPUTATION_TIME INTEGER,
+                LAST_UPDATE VARCHAR
+                )"""
+                //Update reporting to the zone table
+                datasource.execute"""update ${zoneTable} 
+                set nb_estimated_building = ${nbBuildingEstimated}, 
+                nb_building = ${nbBuilding}, 
+                nb_block =  ${nbBlock},
+                nb_rsu = ${nbRSU},
+                computation_time = ${(System.currentTimeMillis()-start)/1000},
+                last_update = CAST(now() AS VARCHAR)"""
+
                 //Clean the System properties that stores intermediate table names
                 clearTablesCache()
                 return [outputTableBuildingIndicators   : computeBuildingsIndicators.getResults().outputTableName,
@@ -1426,29 +1456,24 @@ IProcess computeAllGeoIndicators() {
                         outputTableBuildingUrbanTypo    : urbanTypoBuilding]
 
             }
-            else{
-                IProcess geoIndicators =  computeGeoclimateIndicators()
+            else {
+                clearTablesCache()
+                IProcess geoIndicators = computeGeoclimateIndicators()
                 if (!geoIndicators.execute(datasource: datasource, zoneTable: zoneTable,
                         buildingTable: buildingTable,
                         roadTable: roadTable,
                         railTable: railTable, vegetationTable: vegetationTable,
                         hydrographicTable: hydrographicTable, imperviousTable: imperviousTable,
                         surface_vegetation: surface_vegetation, surface_hydro: surface_hydro,
-                        indicatorUse:indicatorUse,
+                        indicatorUse: indicatorUse,
                         svfSimplified: svfSimplified, prefixName: prefixName,
                         mapOfWeights: mapOfWeights,
-                        urbanTypoModelName:urbanTypoModelName)){
+                        urbanTypoModelName: urbanTypoModelName)) {
                     error "Cannot build the geoindicators"
                     return
+                } else {
+                    return geoIndicators.getResults()
                 }
-                //Drop all cached tables
-                def cachedTableNames = getCachedTableNames()
-                if(cachedTableNames) {
-                    datasource.execute "DROP TABLE IF EXISTS ${cachedTableNames.join(",")}"
-                }
-                //Clean the System properties that stores intermediate table names
-                clearTablesCache()
-                return geoIndicators.getResults()
             }
         }
     }
@@ -1471,7 +1496,7 @@ IProcess computeGeoclimateIndicators() {
     return create {
         title "Compute all geoindicators"
         id "computeAllGeoIndicators"
-        inputs datasource: JdbcDataSource, zoneTable: "", buildingTable: "",
+        inputs datasource: JdbcDataSource, zoneTable: String, buildingTable: String,
                 roadTable: "", railTable: "", vegetationTable: "",
                 hydrographicTable: "", imperviousTable: "", surface_vegetation: 10000, surface_hydro: 2500,
                 snappingTolerance: 0.01, indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"], svfSimplified: false, prefixName: "",
@@ -1488,7 +1513,7 @@ IProcess computeGeoclimateIndicators() {
               surface_vegetation, surface_hydro, snappingTolerance, indicatorUse, svfSimplified, prefixName, mapOfWeights,
                urbanTypoModelName ->
             info "Start computing the geoindicators..."
-
+            def start =  System.currentTimeMillis()
             // Temporary (and output tables) are created
             def lczIndicTable = postfix "LCZ_INDIC_TABLE"
             def baseNameUrbanTypoRsu = prefix prefixName, "URBAN_TYPO_RSU_"
@@ -1747,6 +1772,31 @@ IProcess computeGeoclimateIndicators() {
             }
 
             datasource.execute "DROP TABLE IF EXISTS $rsuLczWithoutGeom;"
+
+            //Populate reporting
+            def nbBuilding = datasource.firstRow("select count(*) as count from ${buildingIndicators} WHERE ID_RSU IS NOT NULL").count
+            def nbBlock = 0
+            if(blockIndicators){
+             nbBlock = datasource.firstRow("select count(*) as count from ${blockIndicators}").count
+            }
+            def nbRSU = datasource.firstRow("select count(*) as count from ${rsuIndicators}").count
+            //Alter the zone table to add statics
+            datasource.execute"""ALTER TABLE ${zoneTable} ADD COLUMN (
+                NB_BUILDING INTEGER,
+                NB_ESTIMATED_BUILDING INTEGER,
+                NB_BLOCK INTEGER,
+                NB_RSU INTEGER,
+                COMPUTATION_TIME INTEGER,
+                LAST_UPDATE VARCHAR
+                )"""
+            //Update reporting to the zone table
+            datasource.execute"""update ${zoneTable} 
+            set nb_estimated_building = 0, 
+            nb_building = ${nbBuilding}, 
+            nb_block =  ${nbBlock},
+            nb_rsu = ${nbRSU},
+            computation_time = ${(System.currentTimeMillis()-start)/1000},
+            last_update = CAST(now() AS VARCHAR)"""
 
             return [outputTableBuildingIndicators   : buildingIndicators,
                     outputTableBlockIndicators      : blockIndicators,

--- a/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
+++ b/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
@@ -1410,7 +1410,10 @@ IProcess computeAllGeoIndicators() {
 
                 datasource.execute "DROP TABLE IF EXISTS $rsuLczWithoutGeom;"
                 //Drop all cached tables
-                datasource.execute "DROP TABLE IF EXISTS ${getCachedTableNames().join(",")}"
+                def cachedTableNames = getCachedTableNames()
+                if(cachedTableNames) {
+                    datasource.execute "DROP TABLE IF EXISTS ${cachedTableNames.join(",")}"
+                }
                 //Clean the System properties that stores intermediate table names
                 clearTablesCache()
                 return [outputTableBuildingIndicators   : computeBuildingsIndicators.getResults().outputTableName,
@@ -1439,7 +1442,10 @@ IProcess computeAllGeoIndicators() {
                     return
                 }
                 //Drop all cached tables
-                datasource.execute "DROP TABLE IF EXISTS ${getCachedTableNames().join(",")}"
+                def cachedTableNames = getCachedTableNames()
+                if(cachedTableNames) {
+                    datasource.execute "DROP TABLE IF EXISTS ${cachedTableNames.join(",")}"
+                }
                 //Clean the System properties that stores intermediate table names
                 clearTablesCache()
                 return geoIndicators.getResults()

--- a/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/ProcessingChain.groovy
+++ b/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/ProcessingChain.groovy
@@ -28,4 +28,68 @@ abstract class ProcessingChain extends GroovyProcessFactory {
             return prefixName + "_" + baseName
         }
     }
+
+    /**
+     * Return a list of cached table names
+     * @return
+     */
+    static def enableTableCache(){
+        return System.setProperty("GEOCLIMATE_CACHE","true")
+    }
+
+    /**
+     * Return a list of cached table names
+     * @return
+     */
+    static def isTableCacheEnable(){
+        return System.getProperty("GEOCLIMATE_CACHE")?true:false
+    }
+
+    /**
+     * Return a list of cached table names
+     * @return
+     */
+    static def getCachedTableNames(){
+        return System.properties.findAll{it.key.startsWith("GEOCLIMATE_TABLE")}.collect{key, value -> value}
+    }
+
+    /**
+     * Remove from the list of table names the cached tables
+     * @return
+     */
+    static def removeAllCachedTableNames(def tableNames){
+        if(isTableCacheEnable()) {
+            tableNames.removeAll(getCachedTableNames())
+        }
+        return tableNames
+    }
+
+    /**
+     * Return the cached table name from its identifier
+     *
+     * @return
+     */
+    static def getCachedTableName(tableIdentifier){
+        return System.getProperty(tableIdentifier)
+    }
+
+    /**
+     * Add a table if the System properties to cache it
+     * The table is prefixed with the name GEOCLIMATE_
+     *
+     * @return
+     */
+    static void cacheTableName(baseTableName, outputTableName){
+        if(isTableCacheEnable()) {
+            System.setProperty("GEOCLIMATE_TABLE_" + baseTableName, outputTableName)
+        }
+    }
+
+    /**
+     * Clean the System properties that stores intermediate table names
+     * @return
+     */
+    static  void clearTablesCache(){
+        System.properties.removeAll {it.key.startsWith("GEOCLIMATE")}
+    }
 }


### PR DESCRIPTION
This PR introduces

-  a new vegetation type called grass to identify village_green value in OSM for roundabouts
- a new impervious type  to keep construction from OSM
- a mechanism to cache a table name using System.properties

if the developer wants to cache a table name to avoid re-computation it must activate the Geoclimate cache with the method
enableTableCache()

To cache a table it must use cacheTableName(baseTableName, outputTableName)
where baseTableName is an identifier for the table and outputTableName the name of the table in the database

a baseTableName is prefixed with "GEOCLIMATE_TABLE_" so we can find all the cached table in the system.propreties with

```System.properties.findAll{it.key.startsWith("GEOCLIMATE_TABLE")}.collect{key, value -> value}```


This PR adds some statical informations on  the zone table as number of buildings, blocks, rsu. Number of estimated heigth. Useful for OSM processing. 