### PR TITLE
Process to compute indicators on a grid

### DIFF
--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/AbstractTablesInitialization.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/AbstractTablesInitialization.groovy
@@ -3,7 +3,6 @@ package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 import groovy.transform.BaseScript
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
 
 @BaseScript BDTopo_V2_Utils bdTopo_v2_utils
 

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/BDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/BDTopo_V2.groovy
@@ -1,7 +1,6 @@
 package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
-import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
-import org.slf4j.LoggerFactory
+
 
 /**
  * Class to manage and access to the BDTOPO processes

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/InputDataFormatting.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/InputDataFormatting.groovy
@@ -3,7 +3,6 @@ package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 import groovy.transform.BaseScript
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
 
 @BaseScript BDTopo_V2_Utils bdTopo_v2_utils
 

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/PrepareBDTopo.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/PrepareBDTopo.groovy
@@ -3,7 +3,6 @@ package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 import groovy.transform.BaseScript
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
 import org.orbisgis.orbisdata.processmanager.process.ProcessMapper
 
 @BaseScript BDTopo_V2_Utils bdTopo_v2_utils

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
@@ -75,9 +75,10 @@ import java.sql.SQLException
  *     ,
  *   [OPTIONAL ENTRY]  "parameters":
  *     {"distance" : 1000,
+ *     "prefixName": "",
+ *          rsu_indicators:{
  *         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
- *         "svfSimplified": false,
- *         "prefixName": "",
+ *         "svfSimplified": false, *
  *         "mapOfWeights":
  *         {"sky_view_factor"                : 4,
  *          "aspect_ratio"                   : 3,
@@ -89,6 +90,7 @@ import java.sql.SQLException
  *         "hLevMin": 3,
  *         "hLevMax": 15,
  *         "hThresho2": 10
+ *         }
  *     }
  *     }
  * The parameters entry tag contains all geoclimate chain parameters.
@@ -205,7 +207,7 @@ IProcess workflow() {
                             id_zones = inputFolder.id_zones
                         }
                         if (output) {
-                            def geoclimatetTableNames = ["building_indicators",
+                            def geoclimateTableNames = ["building_indicators",
                                                          "block_indicators",
                                                          "rsu_indicators",
                                                          "rsu_lcz",
@@ -219,7 +221,8 @@ IProcess workflow() {
                                                          "urban_areas",
                                                          "rsu_urban_typo_area",
                                                          "rsu_urban_typo_floor_area",
-                                                         "building_urban_typo"]
+                                                         "building_urban_typo",
+                                                         "grid_indicators"]
                             //Get processing parameters
                             def processing_parameters = extractProcessingParameters(parameters.parameters)
                             if(!processing_parameters){
@@ -251,7 +254,7 @@ IProcess workflow() {
                                 }
                                 //Check not the conditions for the output database
                                 def outputTableNames = outputDataBase.get("tables")
-                                def allowedOutputTableNames = geoclimatetTableNames.intersect(outputTableNames.keySet())
+                                def allowedOutputTableNames = geoclimateTableNames.intersect(outputTableNames.keySet())
                                 def notSameTableNames = allowedOutputTableNames.groupBy { it.value }.size() !=
                                         allowedOutputTableNames.size()
                                 if (!allowedOutputTableNames && notSameTableNames) {
@@ -332,7 +335,7 @@ IProcess workflow() {
 
                             } else if (outputDataBase) {
                                 def outputTableNames = outputDataBase.tables
-                                def allowedOutputTableNames = geoclimatetTableNames.intersect(outputTableNames.keySet())
+                                def allowedOutputTableNames = geoclimateTableNames.intersect(outputTableNames.keySet())
                                 def notSameTableNames = allowedOutputTableNames.groupBy { it.value }.size() !=
                                         allowedOutputTableNames.size()
                                 if (allowedOutputTableNames && !notSameTableNames) {
@@ -998,21 +1001,7 @@ def findIDZones(def h2gis_datasource, def id_zones){
  */
 def extractProcessingParameters(def processing_parameters){
     def defaultParameters = [distance: 1000,
-                             distance_buffer:500,
-                             indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
-                             svfSimplified:false, prefixName: "",
-                             surface_vegetation: 10000,
-                             surface_hydro: 2500,
-                             snappingTolerance :0.01,
-                             mapOfWeights : ["sky_view_factor"                : 4,
-                                             "aspect_ratio"                   : 3,
-                                             "building_surface_fraction"      : 8,
-                                             "impervious_surface_fraction"    : 0,
-                                             "pervious_surface_fraction"      : 0,
-                                             "height_of_roughness_elements"   : 6,
-                                             "terrain_roughness_length"       : 0.5],
-                             hLevMin : 3, hLevMax: 15, hThresholdLev2: 10,
-                             urbanTypoModelName: "URBAN_TYPOLOGY_BDTOPO_V2_RF_2_0.model"]
+                             distance_buffer:500,prefixName: ""]
     if(processing_parameters){
         def distanceP =  processing_parameters.distance
         if(distanceP && distanceP in Number){
@@ -1022,56 +1011,117 @@ def extractProcessingParameters(def processing_parameters){
         if(distance_bufferP && distance_bufferP in Number){
             defaultParameters.distance_buffer = distance_bufferP
         }
-        def snappingToleranceP =  processing_parameters.snappingTolerance
-        if(snappingToleranceP && snappingToleranceP in Number){
-            defaultParameters.snappingTolerance = snappingToleranceP
-        }
-        def surface_vegetationP =  processing_parameters.surface_vegetation
-        if(surface_vegetationP && surface_vegetationP in Number){
-            defaultParameters.surface_vegetation = surface_vegetationP
-        }
-        def surface_hydroP =  processing_parameters.surface_hydro
-        if(surface_hydroP && surface_hydroP in Number){
-            defaultParameters.surface_hydro = surface_hydroP
-        }
-
-        def indicatorUseP = processing_parameters.indicatorUse
-        if(indicatorUseP && indicatorUseP in List){
-            defaultParameters.indicatorUse = indicatorUseP
-        }
-
-        def svfSimplifiedP = processing_parameters.svfSimplified
-        if(svfSimplifiedP && svfSimplifiedP in Boolean){
-            defaultParameters.svfSimplified = svfSimplifiedP
-        }
         def prefixNameP = processing_parameters.prefixName
         if(prefixNameP && prefixNameP in String){
             defaultParameters.prefixName = prefixNameP
         }
 
-        def mapOfWeightsP = processing_parameters.mapOfWeights
-        if(mapOfWeightsP && mapOfWeightsP in Map){
-            def defaultmapOfWeights = defaultParameters.mapOfWeights
-            if((defaultmapOfWeights+mapOfWeightsP).size()!=defaultmapOfWeights.size()){
-                error "The number of mapOfWeights parameters must contain exactly the parameters ${defaultmapOfWeights.keySet().join(",")}"
-                return
+        //Check for rsu indicators
+        def  rsu_indicators = processing_parameters.rsu_indicators
+        if(rsu_indicators){
+            def rsu_indicators_default =[indicatorUse: [],
+                                         svfSimplified:false,
+                                         surface_vegetation: 10000,
+                                         surface_hydro: 2500,
+                                         snappingTolerance :0.01,
+                                         mapOfWeights :  ["sky_view_factor"                : 4,
+                                                          "aspect_ratio"                   : 3,
+                                                          "building_surface_fraction"      : 8,
+                                                          "impervious_surface_fraction"    : 0,
+                                                          "pervious_surface_fraction"      : 0,
+                                                          "height_of_roughness_elements"   : 6,
+                                                          "terrain_roughness_length"       : 0.5],
+                                         hLevMin : 3, hLevMax: 15, hThresholdLev2: 10,
+                                         urbanTypoModelName: "URBAN_TYPOLOGY_BDTOPO_V2_RF_2_0.model"]
+            def indicatorUseP = rsu_indicators.indicatorUse
+            if(indicatorUseP && indicatorUseP in List) {
+                def allowed_rsu_indicators = ["LCZ", "URBAN_TYPOLOGY", "TEB"]
+                def allowedOutputRSUIndicators = allowed_rsu_indicators.intersect(indicatorUseP*.toUpperCase())
+                if (allowedOutputRSUIndicators) {
+                    rsu_indicators_default.indicatorUse = indicatorUseP
+                }
+                else {
+                    info "Please set a valid list of RSU indicator names in ${allowedOutputRSUIndicators}"
+                    return
+                }
             }else{
-            defaultParameters.mapOfWeights = mapOfWeightsP
+                info "The list of RSU indicator names cannot be null or empty"
+                return
+            }
+            def snappingToleranceP =  rsu_indicators.snappingTolerance
+            if(snappingToleranceP && snappingToleranceP in Number){
+                rsu_indicators_default.snappingTolerance = snappingToleranceP
+            }
+            def surface_vegetationP =  rsu_indicators.surface_vegetation
+            if(surface_vegetationP && surface_vegetationP in Number){
+                rsu_indicators_default.surface_vegetation = surface_vegetationP
+            }
+            def surface_hydroP =  rsu_indicators.surface_hydro
+            if(surface_hydroP && surface_hydroP in Number){
+                rsu_indicators_default.surface_hydro = surface_hydroP
+            }
+            def svfSimplifiedP = rsu_indicators.svfSimplified
+            if(svfSimplifiedP && svfSimplifiedP in Boolean){
+                rsu_indicators_default.svfSimplified = svfSimplifiedP
+            }
+            def hLevMinP =  rsu_indicators.hLevMin
+            if(hLevMinP && hLevMinP in Integer){
+                rsu_indicators_default.hLevMin = hLevMinP
+            }
+            def hLevMaxP =  rsu_indicators.hLevMax
+            if(hLevMaxP && hLevMaxP in Integer){
+                rsu_indicators_default.hLevMax = hLevMaxP
+            }
+            def hThresholdLev2P =  rsu_indicators.hThresholdLev2
+            if(hThresholdLev2P && hThresholdLev2P in Integer){
+                rsu_indicators_default.hThresholdLev2 = hThresholdLev2P
+            }
+
+            def mapOfWeightsP = rsu_indicators.mapOfWeights
+            if(mapOfWeightsP && mapOfWeightsP in Map){
+                def defaultmapOfWeights = rsu_indicators_default.mapOfWeights
+                if((defaultmapOfWeights+mapOfWeightsP).size()!=defaultmapOfWeights.size()){
+                    error "The number of mapOfWeights parameters must contain exactly the parameters ${defaultmapOfWeights.keySet().join(",")}"
+                    return
+                }else{
+                    rsu_indicators_default.mapOfWeights = mapOfWeightsP
+                }
+            }
+            defaultParameters.put("rsu_indicators", rsu_indicators_default)
+        }
+        //Check for grid indicators
+        def  grid_indicators = processing_parameters.grid_indicators
+        if(grid_indicators){
+            def x_size = grid_indicators.x_size
+            def y_size = grid_indicators.y_size
+            def list_indicators = grid_indicators.indicators
+            if(x_size && y_size){
+                if(x_size<=0 || y_size<= 0){
+                    info "Invalid grid size padding. Must be greater that 0"
+                    return
+                }
+                if(!list_indicators){
+                    info "The list of indicator names cannot be null or empty"
+                    return
+                }
+                def allowed_grid_indicators=["BUILDING_FRACTION","BUILDING_HEIGHT", "WATER_FRACTION","VEGETATION_FRACTION",
+                                             "ROAD_FRACTION", "IMPERVIOUS_FRACTION", "RSU_URBAN_TYPO_FRACTION", "RSU_LCZ_FRACTION"]
+                def allowedOutputIndicators = allowed_grid_indicators.intersect(list_indicators*.toUpperCase())
+                if(allowedOutputIndicators){
+                    def grid_indicators_tmp =  [
+                            "x_size": x_size,
+                            "y_size": y_size,
+                            "indicators": allowedOutputIndicators
+                    ]
+                    defaultParameters.put("grid_indicators", grid_indicators_tmp)
+                }
+                else {
+                    info "Please set a valid list of indicator names in ${allowed_grid_indicators}"
+                    return
+                }
             }
         }
-
-        def hLevMinP =  processing_parameters.hLevMin
-        if(hLevMinP && hLevMinP in Integer){
-            defaultParameters.hLevMin = hLevMinP
-        }
-        def hLevMaxP =  processing_parameters.hLevMax
-        if(hLevMaxP && hLevMaxP in Integer){
-            defaultParameters.hLevMax = hLevMaxP
-        }
-        def hThresholdLev2P =  processing_parameters.hThresholdLev2
-        if(hThresholdLev2P && hThresholdLev2P in Integer){
-            defaultParameters.hThresholdLev2 = hThresholdLev2P
-        }
+        return defaultParameters
     }
     return defaultParameters
 }
@@ -1093,7 +1143,6 @@ def extractProcessingParameters(def processing_parameters){
  */
 def bdtopo_processing(def  h2gis_datasource, def processing_parameters,def id_zones, def outputFolder, def outputFiles, def output_datasource, def outputTableNames, def outputSRID, def deleteOutputData=true){
     def  srid =  h2gis_datasource.getSpatialTable("IRIS_GE").srid
-
     if(!(id_zones in Collection)){
         id_zones = [id_zones]
     }
@@ -1136,36 +1185,66 @@ def bdtopo_processing(def  h2gis_datasource, def processing_parameters,def id_zo
             def imperviousTableName = prepareBDTopoData.results.outputImpervious
 
             info "BDTOPO V2 GIS layers formated"
-            //Build the indicators
-            IProcess geoIndicators = ProcessingChain.GeoIndicatorsChain.computeAllGeoIndicators()
-            if (!geoIndicators.execute(datasource: h2gis_datasource, zoneTable: zoneTableName,
-                    buildingTable: buildingTableName, roadTable: roadTableName,
-                    railTable: railTableName, vegetationTable: vegetationTableName,
-                    hydrographicTable: hydrographicTableName, imperviousTable :imperviousTableName,
-                    surface_vegetation: processing_parameters.surface_vegetation, surface_hydro: processing_parameters.surface_hydro,
-                    snappingTolerance : processing_parameters.snappingTolerance,
-                    indicatorUse: processing_parameters.indicatorUse,
-                    svfSimplified: processing_parameters.svfSimplified, prefixName: processing_parameters.prefixName,
-                    mapOfWeights: processing_parameters.mapOfWeights,
-                    urbanTypoModelName: "URBAN_TYPOLOGY_BDTOPO_V2_RF_2_1.model")) {
-                error "Cannot build the geoindicators for the zone $id_zone"
-            } else {
-                def results = geoIndicators.results
-                results.put("buildingTableName", buildingTableName)
-                results.put("roadTableName", roadTableName)
-                results.put("railTableName", railTableName)
-                results.put("hydrographicTableName", hydrographicTableName)
-                results.put("vegetationTableName", vegetationTableName)
-                results.put("imperviousTableName", imperviousTableName)
-                if (outputFolder  && outputFiles) {
-                    saveOutputFiles(h2gis_datasource, id_zone, results, outputFiles, outputFolder, "bdtopo_v2_", outputSRID, reproject, deleteOutputData)
-                }
-                if (output_datasource ) {
-                    saveTablesInDatabase(output_datasource, h2gis_datasource, outputTableNames, results, id_zone, srid, outputSRID, reproject)
 
+            def rsu_indicators_params = processing_parameters.rsu_indicators
+            def grid_indicators_params = processing_parameters.grid_indicators
+
+            //Add the GIS layers to the list of results
+            def results = [:]
+            results.put("buildingTableName", buildingTableName)
+            results.put("roadTableName", roadTableName)
+            results.put("railTableName", railTableName)
+            results.put("hydrographicTableName", hydrographicTableName)
+            results.put("vegetationTableName", vegetationTableName)
+            results.put("imperviousTableName", imperviousTableName)
+
+            //Compute the RSU indicators
+            if(rsu_indicators_params){
+                //Build the indicators
+                IProcess geoIndicators = ProcessingChain.GeoIndicatorsChain.computeAllGeoIndicators()
+                if (!geoIndicators.execute(datasource: h2gis_datasource, zoneTable: zoneTableName,
+                        buildingTable: buildingTableName, roadTable: roadTableName,
+                        railTable: railTableName, vegetationTable: vegetationTableName,
+                        hydrographicTable: hydrographicTableName, imperviousTable :imperviousTableName,
+                        surface_vegetation: rsu_indicators_params.surface_vegetation, surface_hydro: rsu_indicators_params.surface_hydro,
+                        snappingTolerance : rsu_indicators_params.snappingTolerance,
+                        indicatorUse: rsu_indicators_params.indicatorUse,
+                        svfSimplified: rsu_indicators_params.svfSimplified, prefixName: processing_parameters.prefixName,
+                        mapOfWeights: rsu_indicators_params.mapOfWeights,
+                        urbanTypoModelName: "URBAN_TYPOLOGY_BDTOPO_V2_RF_2_1.model")) {
+                    error "Cannot build the geoindicators for the zone $id_zone"
+                } else {
+                    results.putAll(geoIndicators.getResults())
                 }
-                info "${id_zone} has been processed"
             }
+            //Compute the grid indicators
+            if(grid_indicators_params) {
+                def x_size = grid_indicators_params.x_size
+                def y_size = grid_indicators_params.y_size
+                IProcess rasterizedIndicators =  ProcessingChain.GeoIndicatorsChain.rasterizeIndicators()
+                if(rasterizedIndicators.execute(datasource:h2gis_datasource,zoneEnvelopeTableName: zoneTableName,
+                        x_size : x_size, y_size : y_size,list_indicators :grid_indicators_params.indicators,
+                        buildingTable: buildingTableName, roadTable: roadTableName, vegetationTable: vegetationTableName,
+                        hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName,
+                        rsu_lcz:results.outputTableRsuLcz,
+                        rsu_urban_typo_area:results.outputTableRsuUrbanTypoArea,
+                        prefixName: processing_parameters.prefixName
+                )){
+                    results.put("grid_indicators", rasterizedIndicators.results.outputTableName)
+                    ouputTableFiles<<rasterizedIndicators.results.outputTableName
+                }
+            }
+
+            if (outputFolder  && outputFiles) {
+                saveOutputFiles(h2gis_datasource, id_zone, results, outputFiles, outputFolder, "bdtopo_v2_", outputSRID, reproject, deleteOutputData)
+            }
+            if (output_datasource ) {
+                saveTablesInDatabase(output_datasource, h2gis_datasource, outputTableNames, results, id_zone, srid, outputSRID, reproject)
+
+            }
+            info "${id_zone} has been processed"
+
+
         }
         info "Number of areas processed ${index+1} on $nbAreas"
     }
@@ -1231,6 +1310,8 @@ def saveOutputFiles(def h2gis_datasource, def id_zone, def results, def outputFi
             saveTableAsGeojson(results.outputTableRsuUrbanTypoFloorArea, "${subFolder.getAbsolutePath()+File.separator+"rsu_urban_typo_floor_area"}.geojson", h2gis_datasource,outputSRID,reproject,deleteOutputData)
         }else if(it.equals("building_urban_typo")){
             saveTableAsGeojson(results.outputTableBuildingUrbanTypo, "${subFolder.getAbsolutePath()+File.separator+"building_urban_typo"}.geojson", h2gis_datasource,outputSRID,reproject,deleteOutputData)
+        }else if(it.equals("grid_indicators")){
+            saveTableAsGeojson(results.grid_indicators, "${subFolder.getAbsolutePath()+File.separator+"grid_indicators"}.geojson", h2gis_datasource,outputSRID,reproject,deleteOutputData)
         }
     }
 }
@@ -1758,6 +1839,10 @@ def saveTablesInDatabase(def output_datasource, def h2gis_datasource, def output
 
     //Export building_urban_typo
     indicatorTableBatchExportTable(output_datasource, outputTableNames.building_urban_typo,id_zone,h2gis_datasource, h2gis_tables.outputTableBuildingUrbanTypo
+            , "",inputSRID,outputSRID,reproject)
+
+    //Export grid_indicators
+    indicatorTableBatchExportTable(output_datasource, outputTableNames.grid_indicators,id_zone,h2gis_datasource, h2gis_tables.grid_indicators
             , "",inputSRID,outputSRID,reproject)
 
     //Export zone

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
@@ -1001,7 +1001,8 @@ def findIDZones(def h2gis_datasource, def id_zones){
  */
 def extractProcessingParameters(def processing_parameters){
     def defaultParameters = [distance: 1000,
-                             distance_buffer:500,prefixName: ""]
+                             distance_buffer:500,prefixName: "",
+                             hLevMin : 3, hLevMax: 15, hThresholdLev2: 10]
     if(processing_parameters){
         def distanceP =  processing_parameters.distance
         if(distanceP && distanceP in Number){
@@ -1014,6 +1015,18 @@ def extractProcessingParameters(def processing_parameters){
         def prefixNameP = processing_parameters.prefixName
         if(prefixNameP && prefixNameP in String){
             defaultParameters.prefixName = prefixNameP
+        }
+        def hLevMinP =  processing_parameters.hLevMin
+        if(hLevMinP && hLevMinP in Integer){
+            defaultParameters.hLevMin = hLevMinP
+        }
+        def hLevMaxP =  processing_parameters.hLevMax
+        if(hLevMaxP && hLevMaxP in Integer){
+            defaultParameters.hLevMax = hLevMaxP
+        }
+        def hThresholdLev2P =  processing_parameters.hThresholdLev2
+        if(hThresholdLev2P && hThresholdLev2P in Integer){
+            defaultParameters.hThresholdLev2 = hThresholdLev2P
         }
 
         //Check for rsu indicators
@@ -1031,7 +1044,6 @@ def extractProcessingParameters(def processing_parameters){
                                                           "pervious_surface_fraction"      : 0,
                                                           "height_of_roughness_elements"   : 6,
                                                           "terrain_roughness_length"       : 0.5],
-                                         hLevMin : 3, hLevMax: 15, hThresholdLev2: 10,
                                          urbanTypoModelName: "URBAN_TYPOLOGY_BDTOPO_V2_RF_2_0.model"]
             def indicatorUseP = rsu_indicators.indicatorUse
             if(indicatorUseP && indicatorUseP in List) {
@@ -1063,18 +1075,6 @@ def extractProcessingParameters(def processing_parameters){
             def svfSimplifiedP = rsu_indicators.svfSimplified
             if(svfSimplifiedP && svfSimplifiedP in Boolean){
                 rsu_indicators_default.svfSimplified = svfSimplifiedP
-            }
-            def hLevMinP =  rsu_indicators.hLevMin
-            if(hLevMinP && hLevMinP in Integer){
-                rsu_indicators_default.hLevMin = hLevMinP
-            }
-            def hLevMaxP =  rsu_indicators.hLevMax
-            if(hLevMaxP && hLevMaxP in Integer){
-                rsu_indicators_default.hLevMax = hLevMaxP
-            }
-            def hThresholdLev2P =  rsu_indicators.hThresholdLev2
-            if(hThresholdLev2P && hThresholdLev2P in Integer){
-                rsu_indicators_default.hThresholdLev2 = hThresholdLev2P
             }
 
             def mapOfWeightsP = rsu_indicators.mapOfWeights
@@ -1191,12 +1191,12 @@ def bdtopo_processing(def  h2gis_datasource, def processing_parameters,def id_zo
 
             //Add the GIS layers to the list of results
             def results = [:]
-            results.put("buildingTableName", buildingTableName)
             results.put("roadTableName", roadTableName)
             results.put("railTableName", railTableName)
             results.put("hydrographicTableName", hydrographicTableName)
             results.put("vegetationTableName", vegetationTableName)
             results.put("imperviousTableName", imperviousTableName)
+            results.put("outputTableBuildingIndicators", buildingTableName)
 
             //Compute the RSU indicators
             if(rsu_indicators_params){
@@ -1224,7 +1224,7 @@ def bdtopo_processing(def  h2gis_datasource, def processing_parameters,def id_zo
                 IProcess rasterizedIndicators =  ProcessingChain.GeoIndicatorsChain.rasterizeIndicators()
                 if(rasterizedIndicators.execute(datasource:h2gis_datasource,zoneEnvelopeTableName: zoneTableName,
                         x_size : x_size, y_size : y_size,list_indicators :grid_indicators_params.indicators,
-                        buildingTable: buildingTableName, roadTable: roadTableName, vegetationTable: vegetationTableName,
+                        buildingTable: results.outputTableBuildingIndicators, roadTable: roadTableName, vegetationTable: vegetationTableName,
                         hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName,
                         rsu_lcz:results.outputTableRsuLcz,
                         rsu_urban_typo_area:results.outputTableRsuUrbanTypoArea,

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/AbstractTablesInitializationTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/AbstractTablesInitializationTest.groovy
@@ -1,10 +1,7 @@
 package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
-import org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory
-import org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager
 
 import static org.junit.jupiter.api.Assertions.*
 

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ChainProcessAbstractTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ChainProcessAbstractTest.groovy
@@ -1,7 +1,6 @@
 package org.orbisgis.orbisprocess.geoclimate.bdtopo_v2
 
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager
 import org.orbisgis.orbisprocess.geoclimate.geoindicators.Geoindicators
 import org.orbisgis.orbisprocess.geoclimate.processingchain.ProcessingChain
 import org.slf4j.Logger

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
@@ -234,7 +234,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
         dirFile.delete()
         dirFile.mkdir()
         IProcess processBDTopo = BDTopo_V2.workflow
-        assertTrue(processBDTopo.execute(configurationFile: getClass().getResource("config/bdtopo_workflow_folderinput_folderoutput_id_zones.json").toURI()))mm
+        assertTrue(processBDTopo.execute(configurationFile: getClass().getResource("config/bdtopo_workflow_folderinput_folderoutput_id_zones.json").toURI()))
         assertNotNull(processBDTopo.getResults().outputFolder)
         def baseNamePathAndFileOut = processBDTopo.getResults().outputFolder + File.separator + "zone_" + communeToTest + "_"
         assertTrue(new File(baseNamePathAndFileOut + "rsu_indicators.geojson").exists())

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
@@ -251,7 +251,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
         //configFile =getClass().getResource("config/bdtopo_workflow_folderinput_dboutput.json").toURI()
         //configFile =getClass().getResource("config/bdtopo_workflow_dbinput_dboutput.json").toURI()
         IProcess process = BDTopo_V2.workflow
-        process.execute(configurationFile:"/home/ebocher/applications/geoclimate/bdtopo_workflow_dbinput_outputfolder_erwan.json")
+        process.execute(configurationFile:configFile)
     }
 
     @Test
@@ -282,9 +282,9 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                             "zones":"zones" ]]],
                 "parameters":
                         ["distance" : 0,
+                          rsu_indicators: [
                          "indicatorUse": ["LCZ", "TEB", "URBAN_TYPOLOGY"],
                          "svfSimplified": true,
-                         "prefixName": "",
                          "mapOfWeights":
                                  ["sky_view_factor": 1,
                                   "aspect_ratio": 1,
@@ -295,7 +295,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                   "terrain_roughness_class": 1  ],
                          "hLevMin": 3,
                          "hLevMax": 15,
-                         "hThresholdLev2": 10
+                         "hThresholdLev2": 10]
                         ]
         ]
         IProcess process = BDTopo_V2.workflow
@@ -331,9 +331,9 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                             "zones":"zones" ]]],
                 "parameters":
                         ["distance" : 0,
+                         rsu_indicators: [
                          "indicatorUse": ["LCZ", "TEB", "URBAN_TYPOLOGY"],
                          "svfSimplified": true,
-                         "prefixName": "",
                          "mapOfWeights":
                                  ["sky_view_factor": 1,
                                   "aspect_ratio": 1,
@@ -344,7 +344,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                   "terrain_roughness_class": 1  ],
                          "hLevMin": 3,
                          "hLevMax": 15,
-                         "hThresholdLev2": 10
+                         "hThresholdLev2": 10]
                         ]
         ]
         IProcess process = BDTopo_V2.workflow
@@ -355,12 +355,13 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
     void runBDTopoWorkflow(){
         def dbSuffixName = "_workflow"
         def inseeCode = communeToTest
-        def defaultParameters = [distance: 1000,distance_buffer:500, indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
-                                 svfSimplified:true, prefixName: "",
+        def defaultParameters = [distance: 1000,distance_buffer:500,prefixName: "",
+                                 rsu_indicators: [ indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
+                                 svfSimplified:true,
                                  mapOfWeights : ["sky_view_factor" : 2, "aspect_ratio": 1, "building_surface_fraction": 4,
                                                  "impervious_surface_fraction" : 0, "pervious_surface_fraction": 0,
                                                  "height_of_roughness_elements": 3, "terrain_roughness_length": 1],
-                                 hLevMin : 3, hLevMax: 15, hThresholdLev2: 10]
+                                 hLevMin : 3, hLevMax: 15, hThresholdLev2: 10]]
         H2GIS h2GISDatabase = loadFiles(inseeCode, dbSuffixName)
         def process = new WorkflowBDTopo_V2().bdtopo_processing(h2GISDatabase, defaultParameters, inseeCode, null, null, null, null, 0);
         checkSpatialTable(h2GISDatabase, "block_indicators")
@@ -373,12 +374,12 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
     void runBDTopoWorkflowWithSRID(){
         def dbSuffixName = "_workflow"
         def inseeCode = communeToTest
-        def defaultParameters = [distance: 1000,distance_buffer:500, indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
-                                 svfSimplified:true, prefixName: "",
+        def defaultParameters = [distance: 1000,distance_buffer:500,  prefixName: "", rsu_indicators: [indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
+                                 svfSimplified:true,
                                  mapOfWeights : ["sky_view_factor" : 2, "aspect_ratio": 1, "building_surface_fraction": 4,
                                                  "impervious_surface_fraction" : 0, "pervious_surface_fraction": 0,
                                                  "height_of_roughness_elements": 3, "terrain_roughness_length": 1],
-                                 hLevMin : 3, hLevMax: 15, hThresholdLev2: 10]
+                                 hLevMin : 3, hLevMax: 15, hThresholdLev2: 10]]
         H2GIS h2GISDatabase = loadFiles(inseeCode, dbSuffixName)
         def outputFolder = "./target/bd_topo_workflow_srid"
         File dirFile = new File(outputFolder)
@@ -448,12 +449,10 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                  "tables": outputTables]],
                 "parameters":
                         ["distance" : 0,
+                         rsu_indicators: [
                          "indicatorUse": ["LCZ", "URBAN_TYPOLOGY"],
-                         "svfSimplified": true,
-                         "prefixName": "",
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10
+                         "svfSimplified": true
+                          ]
                         ]
         ]
         IProcess process = BDTopo_V2.workflow

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
@@ -251,7 +251,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
         //configFile =getClass().getResource("config/bdtopo_workflow_folderinput_dboutput.json").toURI()
         //configFile =getClass().getResource("config/bdtopo_workflow_dbinput_dboutput.json").toURI()
         IProcess process = BDTopo_V2.workflow
-        process.execute(configurationFile:configFile)
+        process.execute(configurationFile:"/home/ebocher/applications/geoclimate/bdtopo_workflow_dbinput_outputfolder_erwan.json")
     }
 
     @Test

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
@@ -282,6 +282,9 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                             "zones":"zones" ]]],
                 "parameters":
                         ["distance" : 0,
+                         "hLevMin": 3,
+                         "hLevMax": 15,
+                         "hThresholdLev2": 10,
                           rsu_indicators: [
                          "indicatorUse": ["LCZ", "TEB", "URBAN_TYPOLOGY"],
                          "svfSimplified": true,
@@ -292,10 +295,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                   "impervious_surface_fraction" : 1,
                                   "pervious_surface_fraction": 1,
                                   "height_of_roughness_elements": 1,
-                                  "terrain_roughness_class": 1  ],
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10]
+                                  "terrain_roughness_class": 1  ]]
                         ]
         ]
         IProcess process = BDTopo_V2.workflow
@@ -331,6 +331,9 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                             "zones":"zones" ]]],
                 "parameters":
                         ["distance" : 0,
+                         "hLevMin": 3,
+                         "hLevMax": 15,
+                         "hThresholdLev2": 10,
                          rsu_indicators: [
                          "indicatorUse": ["LCZ", "TEB", "URBAN_TYPOLOGY"],
                          "svfSimplified": true,
@@ -341,10 +344,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
                                   "impervious_surface_fraction" : 1,
                                   "pervious_surface_fraction": 1,
                                   "height_of_roughness_elements": 1,
-                                  "terrain_roughness_class": 1  ],
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10]
+                                  "terrain_roughness_class": 1  ]]
                         ]
         ]
         IProcess process = BDTopo_V2.workflow
@@ -356,12 +356,15 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
         def dbSuffixName = "_workflow"
         def inseeCode = communeToTest
         def defaultParameters = [distance: 1000,distance_buffer:500,prefixName: "",
+                                 "hLevMin": 3,
+                                 "hLevMax": 15,
+                                 "hThresholdLev2": 10,
                                  rsu_indicators: [ indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
                                  svfSimplified:true,
                                  mapOfWeights : ["sky_view_factor" : 2, "aspect_ratio": 1, "building_surface_fraction": 4,
                                                  "impervious_surface_fraction" : 0, "pervious_surface_fraction": 0,
-                                                 "height_of_roughness_elements": 3, "terrain_roughness_length": 1],
-                                 hLevMin : 3, hLevMax: 15, hThresholdLev2: 10]]
+                                                 "height_of_roughness_elements": 3, "terrain_roughness_length": 1]
+                                 ]]
         H2GIS h2GISDatabase = loadFiles(inseeCode, dbSuffixName)
         def process = new WorkflowBDTopo_V2().bdtopo_processing(h2GISDatabase, defaultParameters, inseeCode, null, null, null, null, 0);
         checkSpatialTable(h2GISDatabase, "block_indicators")
@@ -374,12 +377,14 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
     void runBDTopoWorkflowWithSRID(){
         def dbSuffixName = "_workflow"
         def inseeCode = communeToTest
-        def defaultParameters = [distance: 1000,distance_buffer:500,  prefixName: "", rsu_indicators: [indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
+        def defaultParameters = [distance: 1000,distance_buffer:500,  prefixName: "",
+                                 "hLevMax": 15,
+                                 "hThresholdLev2": 10,
+                                 rsu_indicators: [indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
                                  svfSimplified:true,
                                  mapOfWeights : ["sky_view_factor" : 2, "aspect_ratio": 1, "building_surface_fraction": 4,
                                                  "impervious_surface_fraction" : 0, "pervious_surface_fraction": 0,
-                                                 "height_of_roughness_elements": 3, "terrain_roughness_length": 1],
-                                 hLevMin : 3, hLevMax: 15, hThresholdLev2: 10]]
+                                                 "height_of_roughness_elements": 3, "terrain_roughness_length": 1]]]
         H2GIS h2GISDatabase = loadFiles(inseeCode, dbSuffixName)
         def outputFolder = "./target/bd_topo_workflow_srid"
         File dirFile = new File(outputFolder)

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/ProcessingChainBDTopoTest.groovy
@@ -376,12 +376,12 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
         def inseeCode = communeToTest
         def defaultParameters = [distance: 1000,distance_buffer:500,  prefixName: "",
                                  rsu_indicators: [
-                                 indicatorUse: ["LCZ"],
+                                 indicatorUse: ["LCZ", "TEB"],
                                  svfSimplified:true,
                                  mapOfWeights : ["sky_view_factor" : 2, "aspect_ratio": 1, "building_surface_fraction": 4,
                                                  "impervious_surface_fraction" : 0, "pervious_surface_fraction": 0,
                                                  "height_of_roughness_elements": 3, "terrain_roughness_length": 1]]]
-        String directory ="./target/bdtopo_chain_workflow"
+        String directory ="./target/bdtopo_chain_workflow_srid"
         File dirFile = new File(directory)
         if(dirFile.exists()){
             FileUtilities.deleteFiles(dirFile, true)
@@ -406,7 +406,7 @@ class ProcessingChainBDTopoTest extends ChainProcessAbstractTest{
         checkSpatialTable(h2GISDatabase, "rsu_indicators")
         checkSpatialTable(h2GISDatabase, "rsu_lcz")
         def geoFiles = []
-        def  folder = new File("./target/bd_topo_workflow_srid/bdtopo_v2_12174")
+        def  folder = new File(directory+File.separator+"bdtopo_v2_12174")
         folder.eachFileRecurse groovy.io.FileType.FILES,  { file ->
             if (file.name.toLowerCase().endsWith(".geojson")) {
                 geoFiles << file.getAbsolutePath()

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_dbinput_dboutput.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_dbinput_dboutput.json
@@ -39,9 +39,10 @@
     },
     "parameters":
     {"distance" : 1000,
+        "prefixName": "",
+        "rsu_indicators": {
         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
         "svfSimplified": false,
-        "prefixName": "",
         "mapOfWeights":
         {"sky_view_factor": 1,
             "aspect_ratio": 1,
@@ -52,6 +53,6 @@
             "terrain_roughness_class": 1},
         "hLevMin": 3,
         "hLevMax": 15,
-        "hThresholdLev2": 10
+        "hThresholdLev2": 10}
     }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_dbinput_dboutput.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_dbinput_dboutput.json
@@ -40,6 +40,9 @@
     "parameters":
     {"distance" : 1000,
         "prefixName": "",
+        "hLevMin": 3,
+        "hLevMax": 15,
+        "hThresholdLev2": 10,
         "rsu_indicators": {
         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
         "svfSimplified": false,
@@ -50,9 +53,6 @@
             "impervious_surface_fraction" : 1,
             "pervious_surface_fraction": 1,
             "height_of_roughness_elements": 1,
-            "terrain_roughness_class": 1},
-        "hLevMin": 3,
-        "hLevMax": 15,
-        "hThresholdLev2": 10}
+            "terrain_roughness_class": 1}}
     }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_dboutput.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_dboutput.json
@@ -24,19 +24,25 @@
     },
     "parameters":
     {"distance" : 1000,
-        "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
-        "svfSimplified": false,
-        "prefixName": "",
-        "mapOfWeights":
-        {"sky_view_factor": 1,
-            "aspect_ratio": 1,
-            "building_surface_fraction": 1,
-            "impervious_surface_fraction" : 1,
-            "pervious_surface_fraction": 1,
-            "height_of_roughness_elements": 1,
-            "terrain_roughness_class": 1},
-        "hLevMin": 3,
-        "hLevMax": 15,
-        "hThresholdLev2": 10
+        "rsu_indicators": {
+            "indicatorUse": [
+                "LCZ",
+                "URBAN_TYPOLOGY",
+                "TEB"
+            ],
+            "svfSimplified": false,
+            "mapOfWeights": {
+                "sky_view_factor": 1,
+                "aspect_ratio": 1,
+                "building_surface_fraction": 1,
+                "impervious_surface_fraction": 1,
+                "pervious_surface_fraction": 1,
+                "height_of_roughness_elements": 1,
+                "terrain_roughness_class": 1
+            },
+            "hLevMin": 3,
+            "hLevMax": 15,
+            "hThresholdLev2": 10
+        }
     }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_dboutput.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_dboutput.json
@@ -24,6 +24,9 @@
     },
     "parameters":
     {"distance" : 1000,
+        "hLevMin": 3,
+        "hLevMax": 15,
+        "hThresholdLev2": 10,
         "rsu_indicators": {
             "indicatorUse": [
                 "LCZ",
@@ -39,10 +42,7 @@
                 "pervious_surface_fraction": 1,
                 "height_of_roughness_elements": 1,
                 "terrain_roughness_class": 1
-            },
-            "hLevMin": 3,
-            "hLevMax": 15,
-            "hThresholdLev2": 10
+            }
         }
     }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_folderoutput.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_folderoutput.json
@@ -7,6 +7,9 @@
     "folder" : "/tmp/..."},
   "parameters":
   {"distance" : 1000,
+    "hLevMin": 3,
+    "hLevMax": 15,
+    "hThresholdLev2": 10,
     "rsu_indicators": {
     "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
     "svfSimplified": false,
@@ -17,10 +20,7 @@
       "impervious_surface_fraction" : 1,
       "pervious_surface_fraction": 1,
       "height_of_roughness_elements": 1,
-      "terrain_roughness_class": 1},
-    "hLevMin": 3,
-    "hLevMax": 15,
-    "hThresholdLev2": 10
+      "terrain_roughness_class": 1}
     }
   }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_folderoutput.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_folderoutput.json
@@ -7,9 +7,9 @@
     "folder" : "/tmp/..."},
   "parameters":
   {"distance" : 1000,
+    "rsu_indicators": {
     "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
     "svfSimplified": false,
-    "prefixName": "",
     "mapOfWeights":
     {"sky_view_factor": 1,
       "aspect_ratio": 1,
@@ -21,5 +21,6 @@
     "hLevMin": 3,
     "hLevMax": 15,
     "hThresholdLev2": 10
+    }
   }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_folderoutput_id_zones.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_folderoutput_id_zones.json
@@ -13,6 +13,9 @@
      "folder" : "/tmp/..."},
     "parameters":
     {"distance" : 1000,
+        "hLevMin": 3,
+        "hLevMax": 15,
+        "hThresholdLev2": 10,
         "rsu_indicators": {
         "indicatorUse": ["TEB"],
         "svfSimplified": false,
@@ -23,10 +26,7 @@
             "impervious_surface_fraction" : 1,
             "pervious_surface_fraction": 1,
             "height_of_roughness_elements": 1,
-            "terrain_roughness_class": 1},
-        "hLevMin": 3,
-        "hLevMax": 15,
-        "hThresholdLev2": 10
+            "terrain_roughness_class": 1}
         }
     }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_folderoutput_id_zones.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_folderoutput_id_zones.json
@@ -13,9 +13,9 @@
      "folder" : "/tmp/..."},
     "parameters":
     {"distance" : 1000,
+        "rsu_indicators": {
         "indicatorUse": ["TEB"],
         "svfSimplified": false,
-        "prefixName": "",
         "mapOfWeights":
         {"sky_view_factor": 1,
             "aspect_ratio": 1,
@@ -27,5 +27,6 @@
         "hLevMin": 3,
         "hLevMax": 15,
         "hThresholdLev2": 10
+        }
     }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_id_zones_folderoutput_tablenames.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_id_zones_folderoutput_tablenames.json
@@ -21,12 +21,12 @@
              "rail" ,
              "water",
              "vegetation",
-             "impervious"],
+             "impervious"]}},
     "parameters":
     {"distance" : 1000,
+        "rsu_indicators": {
         "indicatorUse": ["TEB"],
         "svfSimplified": false,
-        "prefixName": "",
         "mapOfWeights":
         {"sky_view_factor": 1,
             "aspect_ratio": 1,
@@ -38,5 +38,6 @@
         "hLevMin": 3,
         "hLevMax": 15,
         "hThresholdLev2": 10
+        }
     }
 }

--- a/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_id_zones_folderoutput_tablenames.json
+++ b/bdtopo_v2/src/test/resources/org/orbisgis/orbisprocess/geoclimate/bdtopo_v2/config/bdtopo_workflow_folderinput_id_zones_folderoutput_tablenames.json
@@ -24,6 +24,9 @@
              "impervious"]}},
     "parameters":
     {"distance" : 1000,
+        "hLevMin": 3,
+        "hLevMax": 15,
+        "hThresholdLev2": 10,
         "rsu_indicators": {
         "indicatorUse": ["TEB"],
         "svfSimplified": false,
@@ -34,10 +37,7 @@
             "impervious_surface_fraction" : 1,
             "pervious_surface_fraction": 1,
             "height_of_roughness_elements": 1,
-            "terrain_roughness_class": 1},
-        "hLevMin": 3,
-        "hLevMax": 15,
-        "hThresholdLev2": 10
+            "terrain_roughness_class": 1}
         }
     }
 }

--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/BlockIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/BlockIndicators.groovy
@@ -3,7 +3,6 @@ package org.orbisgis.orbisprocess.geoclimate.geoindicators
 import groovy.transform.BaseScript
 import org.orbisgis.orbisdata.datamanager.jdbc.*
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.process.*
 
 @BaseScript Geoindicators geoindicators
 

--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/BuildingIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/BuildingIndicators.groovy
@@ -3,7 +3,6 @@ package org.orbisgis.orbisprocess.geoclimate.geoindicators
 import groovy.transform.BaseScript
 import org.orbisgis.orbisdata.datamanager.jdbc.*
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.process.*
 
 @BaseScript Geoindicators geoindicators
 

--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/DataUtils.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/DataUtils.groovy
@@ -3,7 +3,6 @@ package org.orbisgis.orbisprocess.geoclimate.geoindicators
 import groovy.transform.BaseScript
 import org.orbisgis.orbisdata.datamanager.jdbc.*
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.process.*
 
 @BaseScript Geoindicators geoindicators
 

--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/RsuIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/RsuIndicators.groovy
@@ -1208,24 +1208,30 @@ IProcess smallestCommunGeometry() {
 return create {
     title "RSU surface features"
     id "smallestCommunGeometry"
-    inputs rsuTable: String, buildingTable: "", roadTable: "", waterTable: "", vegetationTable: "",
+    inputs rsuTable: String, id_rsu : "id_rsu" , buildingTable: "", roadTable: "", waterTable: "", vegetationTable: "",
             imperviousTable: "", prefixName: String, datasource: JdbcDataSource
     outputs outputTableName: String
-    run { rsuTable, buildingTable, roadTable, waterTable, vegetationTable,
+    run { rsuTable, id_rsu, buildingTable, roadTable, waterTable, vegetationTable,
           imperviousTable, prefixName, datasource ->
-
+        //All table names cannot be null or empty
+        if(!buildingTable && !roadTable && !waterTable && !vegetationTable && !imperviousTable){
+            return
+        }
         def BASE_NAME = "RSU_SMALLEST_COMMUN_GEOMETRY"
 
-        info "Executing RSU surface fractions computation"
+        info "Compute the smallest geometries"
+
+        //To avoid column name duplication
+        def ID_COLUMN_NAME =  postfix "id"
 
         // The name of the outputTableName is constructed
         def outputTableName = prefix prefixName, BASE_NAME
 
         if (rsuTable && datasource.hasTable(rsuTable)) {
-            datasource."$rsuTable".id_rsu.createIndex()
+            datasource."$rsuTable"."$id_rsu".createIndex()
             datasource."$rsuTable".the_geom.createSpatialIndex()
             def tablesToMerge = [:]
-            tablesToMerge += ["$rsuTable": "select ST_ExteriorRing(the_geom) as the_geom, id_rsu from $rsuTable"]
+            tablesToMerge += ["$rsuTable": "select ST_ExteriorRing(the_geom) as the_geom, ${id_rsu} from $rsuTable"]
             if (roadTable && datasource.hasTable(roadTable)) {
                 info "Preparing table : $roadTable"
                 datasource."$roadTable".the_geom.createSpatialIndex()
@@ -1237,11 +1243,11 @@ return create {
             AS the_geom
             FROM $roadTable  where ZINDEX=0 ;
             CREATE INDEX IF NOT EXISTS ids_$roadTable_zindex0_buffer ON $roadTable_zindex0_buffer USING RTREE(the_geom);
-            CREATE TABLE $road_tmp AS SELECT ST_CollectionExtract(st_intersection(st_union(st_accum(a.the_geom)),b.the_geom),3) AS the_geom, b.id_rsu FROM
-            $roadTable_zindex0_buffer AS a, $rsuTable AS b WHERE a.the_geom && b.the_geom AND st_intersects(a.the_geom, b.the_geom) GROUP BY b.id_rsu;
+            CREATE TABLE $road_tmp AS SELECT ST_CollectionExtract(st_intersection(st_union(st_accum(a.the_geom)),b.the_geom),3) AS the_geom, b.${id_rsu} FROM
+            $roadTable_zindex0_buffer AS a, $rsuTable AS b WHERE a.the_geom && b.the_geom AND st_intersects(a.the_geom, b.the_geom) GROUP BY b.${id_rsu};
             DROP TABLE IF EXISTS $roadTable_zindex0_buffer;
             """
-                tablesToMerge += ["$road_tmp": "select ST_ToMultiLine(the_geom) as the_geom, id_rsu from $road_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
+                tablesToMerge += ["$road_tmp": "select ST_ToMultiLine(the_geom) as the_geom, ${id_rsu} from $road_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
             }
 
             if (vegetationTable && datasource.hasTable(vegetationTable)) {
@@ -1252,22 +1258,22 @@ return create {
                 def high_vegetation_tmp = postfix "high_vegetation_zindex0"
                 def high_vegetation_rsu_tmp = postfix "high_vegetation_zindex0"
                 datasource """DROP TABLE IF EXISTS $low_vegetation_tmp, $low_vegetation_rsu_tmp;
-                CREATE TABLE $low_vegetation_rsu_tmp as select st_union(st_accum(a.the_geom)) as the_geom,  b.id_rsu FROM 
+                CREATE TABLE $low_vegetation_rsu_tmp as select st_union(st_accum(a.the_geom)) as the_geom,  b.${id_rsu} FROM 
                     $vegetationTable AS a, $rsuTable AS b WHERE a.the_geom && b.the_geom 
-                        AND ST_INTERSECTS(a.the_geom, b.the_geom) and a.height_class='low' group by b.id_rsu;
-                CREATE INDEX ON $low_vegetation_rsu_tmp(id_rsu);
-                CREATE TABLE $low_vegetation_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.id_rsu FROM 
-                        $low_vegetation_rsu_tmp AS a, $rsuTable AS b WHERE a.id_rsu=b.id_rsu group by b.id_rsu;
+                        AND ST_INTERSECTS(a.the_geom, b.the_geom) and a.height_class='low' group by b.${id_rsu};
+                CREATE INDEX ON $low_vegetation_rsu_tmp(${id_rsu});
+                CREATE TABLE $low_vegetation_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.${id_rsu} FROM 
+                        $low_vegetation_rsu_tmp AS a, $rsuTable AS b WHERE a.${id_rsu}=b.${id_rsu} group by b.${id_rsu};
                         DROP TABLE IF EXISTS $high_vegetation_tmp,$high_vegetation_rsu_tmp;
-                CREATE TABLE $high_vegetation_rsu_tmp as select st_union(st_accum(a.the_geom)) as the_geom,  b.id_rsu FROM 
+                CREATE TABLE $high_vegetation_rsu_tmp as select st_union(st_accum(a.the_geom)) as the_geom,  b.${id_rsu} FROM 
                     $vegetationTable AS a, $rsuTable AS b WHERE a.the_geom && b.the_geom 
-                        AND ST_INTERSECTS(a.the_geom, b.the_geom) and a.height_class='high' group by b.id_rsu;
-                CREATE INDEX ON $high_vegetation_rsu_tmp(id_rsu);
-                CREATE TABLE $high_vegetation_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.id_rsu FROM 
-                        $high_vegetation_rsu_tmp AS a, $rsuTable AS b WHERE a.id_rsu=b.id_rsu group by b.id_rsu;
+                        AND ST_INTERSECTS(a.the_geom, b.the_geom) and a.height_class='high' group by b.${id_rsu};
+                CREATE INDEX ON $high_vegetation_rsu_tmp(${id_rsu});
+                CREATE TABLE $high_vegetation_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.${id_rsu} FROM 
+                        $high_vegetation_rsu_tmp AS a, $rsuTable AS b WHERE a.${id_rsu}=b.${id_rsu} group by b.${id_rsu};
                 DROP TABLE $low_vegetation_rsu_tmp, $high_vegetation_rsu_tmp;"""
-                tablesToMerge += ["$low_vegetation_tmp": "select ST_ToMultiLine(the_geom) as the_geom, id_rsu from $low_vegetation_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
-                tablesToMerge += ["$high_vegetation_tmp": "select ST_ToMultiLine(the_geom) as the_geom, id_rsu from $high_vegetation_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
+                tablesToMerge += ["$low_vegetation_tmp": "select ST_ToMultiLine(the_geom) as the_geom, ${id_rsu} from $low_vegetation_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
+                tablesToMerge += ["$high_vegetation_tmp": "select ST_ToMultiLine(the_geom) as the_geom, ${id_rsu} from $high_vegetation_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
             }
 
             if (waterTable && datasource.hasTable(waterTable)) {
@@ -1275,10 +1281,10 @@ return create {
                 datasource."$waterTable".the_geom.createSpatialIndex()
                 def water_tmp = postfix "water_zindex0"
                 datasource """DROP TABLE IF EXISTS $water_tmp;
-                CREATE TABLE $water_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.id_rsu FROM 
+                CREATE TABLE $water_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.${id_rsu} FROM 
                         $waterTable AS a, $rsuTable AS b WHERE a.the_geom && b.the_geom 
                         AND ST_INTERSECTS(a.the_geom, b.the_geom)"""
-                tablesToMerge += ["$water_tmp": "select ST_ToMultiLine(the_geom) as the_geom, id_rsu from $water_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
+                tablesToMerge += ["$water_tmp": "select ST_ToMultiLine(the_geom) as the_geom, ${id_rsu} from $water_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
             }
 
             if (imperviousTable && datasource.hasTable(imperviousTable)) {
@@ -1286,10 +1292,10 @@ return create {
                 datasource."$imperviousTable".the_geom.createSpatialIndex()
                 def impervious_tmp = postfix "impervious_zindex0"
                 datasource """DROP TABLE IF EXISTS $impervious_tmp;
-                CREATE TABLE $impervious_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.id_rsu FROM 
+                CREATE TABLE $impervious_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.${id_rsu} FROM 
                         $imperviousTable AS a, $rsuTable AS b WHERE a.the_geom && b.the_geom 
                         AND ST_INTERSECTS(a.the_geom, b.the_geom)"""
-                tablesToMerge += ["$impervious_tmp": "select ST_ToMultiLine(the_geom) as the_geom, id_rsu from $impervious_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
+                tablesToMerge += ["$impervious_tmp": "select ST_ToMultiLine(the_geom) as the_geom, ${id_rsu} from $impervious_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
             }
 
             if (buildingTable && datasource.hasTable(buildingTable)) {
@@ -1297,10 +1303,10 @@ return create {
                 datasource."$buildingTable".the_geom.createSpatialIndex()
                 def building_tmp = postfix "building_zindex0"
                 datasource """DROP TABLE IF EXISTS $building_tmp;
-                CREATE TABLE $building_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.id_rsu FROM 
+                CREATE TABLE $building_tmp AS SELECT ST_CollectionExtract(st_intersection(a.the_geom, b.the_geom),3) AS the_geom, b.${id_rsu} FROM 
                         $buildingTable AS a, $rsuTable AS b WHERE a.the_geom && b.the_geom 
                         AND ST_INTERSECTS(a.the_geom, b.the_geom) and a.zindex=0"""
-                tablesToMerge += ["$building_tmp": "select ST_ToMultiLine(the_geom) as the_geom, id_rsu from $building_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
+                tablesToMerge += ["$building_tmp": "select ST_ToMultiLine(the_geom) as the_geom, ${id_rsu} from $building_tmp WHERE ST_ISEMPTY(THE_GEOM)=false"]
             }
 
             //Merging all tables in one
@@ -1311,31 +1317,31 @@ return create {
             }
             def tmp_tables = postfix "tmp_tables_zindex0"
             datasource """DROP TABLE if exists $tmp_tables;
-            CREATE TABLE $tmp_tables(the_geom GEOMETRY, id_rsu integer) AS ${tablesToMerge.values().join(' union ')};
+            CREATE TABLE $tmp_tables(the_geom GEOMETRY, ${id_rsu} integer) AS ${tablesToMerge.values().join(' union ')};
                """
 
             //Polygonize the input tables
             info "Generating minimum polygon areas"
             def tmp_point_polygonize = postfix "tmp_point_polygonize_zindex0"
             datasource """DROP TABLE IF EXISTS $tmp_point_polygonize;
-                CREATE TABLE $tmp_point_polygonize as  select  EXPLOD_ID as id, st_pointonsurface(st_force2D(the_geom)) as the_geom ,
-                st_area(the_geom) as area , id_rsu
+                CREATE TABLE $tmp_point_polygonize as  select  EXPLOD_ID as ${ID_COLUMN_NAME}, st_pointonsurface(st_force2D(the_geom)) as the_geom ,
+                st_area(the_geom) as area , ${id_rsu}
                  from st_explode ('(select st_polygonize(st_union(st_force2d(
-                st_precisionreducer(st_node(st_accum(st_force2d(a.the_geom))), 3)))) as the_geom, id_rsu from $tmp_tables as a group by id_rsu)')"""
+                st_precisionreducer(st_node(st_accum(st_force2d(a.the_geom))), 3)))) as the_geom, ${id_rsu} from $tmp_tables as a group by ${id_rsu})')"""
 
             //Create indexes
             datasource."$tmp_point_polygonize".the_geom.createSpatialIndex()
-            datasource."$tmp_point_polygonize".id_rsu.createIndex()
+            datasource."$tmp_point_polygonize"."${id_rsu}".createIndex()
 
             def final_polygonize = postfix "final_polygonize_zindex0"
             datasource """
             DROP TABLE IF EXISTS $final_polygonize;
-            CREATE TABLE $final_polygonize as select a.AREA , a.the_geom, a.id, b.id_rsu
+            CREATE TABLE $final_polygonize as select a.AREA , a.the_geom, a.${ID_COLUMN_NAME}, b.${id_rsu}
             from $tmp_point_polygonize as a, $rsuTable as b
-            where a.the_geom && b.the_geom and st_intersects(a.the_geom, b.the_geom) AND a.ID_RSU =b.ID_RSU"""
+            where a.the_geom && b.the_geom and st_intersects(a.the_geom, b.the_geom) AND a.${id_rsu} =b.${id_rsu}"""
 
             datasource."$final_polygonize".the_geom.createSpatialIndex()
-            datasource."$final_polygonize".id_rsu.createIndex()
+            datasource."$final_polygonize"."${id_rsu}".createIndex()
 
             def finalMerge = []
             tablesToMerge.each { entry ->
@@ -1343,64 +1349,63 @@ return create {
                 def tmptableName = "tmp_stats_$entry.key"
                 if (entry.key.startsWith("high_vegetation")) {
                     datasource."$entry.key".the_geom.createSpatialIndex()
-                    datasource."$entry.key".id_rsu.createIndex()
+                    datasource."$entry.key"."${id_rsu}".createIndex()
                     datasource """DROP TABLE IF EXISTS $tmptableName;
-                CREATE TABLE $tmptableName AS SELECT b.area,0 as low_vegetation, 1 as high_vegetation, 0 as water, 0 as impervious, 0 as road, 0 as building, b.id, b.id_rsu from ${entry.key} as a,
-                $final_polygonize as b where a.the_geom && b.the_geom and st_intersects(a.the_geom, b.the_geom) AND a.ID_RSU =b.ID_RSU"""
+                CREATE TABLE $tmptableName AS SELECT b.area,0 as low_vegetation, 1 as high_vegetation, 0 as water, 0 as impervious, 0 as road, 0 as building, b.${ID_COLUMN_NAME}, b.${id_rsu} from ${entry.key} as a,
+                $final_polygonize as b where a.the_geom && b.the_geom and st_intersects(a.the_geom, b.the_geom) AND a.${id_rsu} =b.${id_rsu}"""
                     finalMerge.add("SELECT * FROM $tmptableName")
                 } else if (entry.key.startsWith("low_vegetation")) {
                     datasource."$entry.key".the_geom.createSpatialIndex()
-                    datasource."$entry.key".id_rsu.createIndex()
+                    datasource."$entry.key"."${id_rsu}".createIndex()
                     datasource """DROP TABLE IF EXISTS $tmptableName;
-                 CREATE TABLE $tmptableName AS SELECT b.area,1 as low_vegetation, 0 as high_vegetation, 0 as water, 0 as impervious, 0 as road, 0 as building, b.id, b.id_rsu from ${entry.key} as a,
-                $final_polygonize as b where a.the_geom && b.the_geom and st_intersects(a.the_geom, b.the_geom) AND a.ID_RSU =b.ID_RSU"""
+                 CREATE TABLE $tmptableName AS SELECT b.area,1 as low_vegetation, 0 as high_vegetation, 0 as water, 0 as impervious, 0 as road, 0 as building, b.${ID_COLUMN_NAME}, b.${id_rsu} from ${entry.key} as a,
+                $final_polygonize as b where a.the_geom && b.the_geom and st_intersects(a.the_geom, b.the_geom) AND a.${id_rsu} =b.${id_rsu}"""
                     finalMerge.add("SELECT * FROM $tmptableName")
                 } else if (entry.key.startsWith("water")) {
                     datasource."$entry.key".the_geom.createSpatialIndex()
-                    datasource."$entry.key".id_rsu.createIndex()
-                    datasource """CREATE TABLE $tmptableName AS SELECT b.area,0 as low_vegetation, 0 as high_vegetation, 1 as water, 0 as impervious, 0 as road,  0 as building, b.id, b.id_rsu from ${entry.key} as a,
-                $final_polygonize as b  where a.the_geom && b.the_geom and st_intersects(a.the_geom, b.the_geom) AND a.ID_RSU =b.ID_RSU"""
+                    datasource."$entry.key"."${id_rsu}".createIndex()
+                    datasource """CREATE TABLE $tmptableName AS SELECT b.area,0 as low_vegetation, 0 as high_vegetation, 1 as water, 0 as impervious, 0 as road,  0 as building, b.${ID_COLUMN_NAME}, b.${id_rsu} from ${entry.key} as a,
+                $final_polygonize as b  where a.the_geom && b.the_geom and st_intersects(a.the_geom, b.the_geom) AND a.${id_rsu} =b.${id_rsu}"""
                     finalMerge.add("SELECT * FROM $tmptableName")
                 } else if (entry.key.startsWith("road")) {
                     datasource."$entry.key".the_geom.createSpatialIndex()
                     datasource """DROP TABLE IF EXISTS $tmptableName;
-                    CREATE TABLE $tmptableName AS SELECT b.area, 0 as low_vegetation, 0 as high_vegetation, 0 as water, 0 as impervious, 1 as road, 0 as building, b.id, b.id_rsu from ${entry.key} as a,
-                $final_polygonize as b where a.the_geom && b.the_geom and ST_intersects(a.the_geom, b.the_geom) AND a.ID_RSU =b.ID_RSU"""
+                    CREATE TABLE $tmptableName AS SELECT b.area, 0 as low_vegetation, 0 as high_vegetation, 0 as water, 0 as impervious, 1 as road, 0 as building, b.${ID_COLUMN_NAME}, b.${id_rsu} from ${entry.key} as a,
+                $final_polygonize as b where a.the_geom && b.the_geom and ST_intersects(a.the_geom, b.the_geom) AND a.${id_rsu} =b.${id_rsu}"""
                     finalMerge.add("SELECT * FROM $tmptableName")
                 } else if (entry.key.startsWith("impervious")) {
                     datasource."$entry.key".the_geom.createSpatialIndex()
-                    datasource."$entry.key".id_rsu.createIndex()
+                    datasource."$entry.key"."${id_rsu}".createIndex()
                     datasource """DROP TABLE IF EXISTS $tmptableName;
-                CREATE TABLE $tmptableName AS SELECT b.area, 0 as low_vegetation, 0 as high_vegetation, 0 as water, 1 as impervious, 0 as road, 0 as building, b.id, b.id_rsu from ${entry.key} as a,
-                $final_polygonize as b where a.the_geom && b.the_geom and ST_intersects(a.the_geom, b.the_geom) AND a.ID_RSU =b.ID_RSU"""
+                CREATE TABLE $tmptableName AS SELECT b.area, 0 as low_vegetation, 0 as high_vegetation, 0 as water, 1 as impervious, 0 as road, 0 as building, b.${ID_COLUMN_NAME}, b.${id_rsu} from ${entry.key} as a,
+                $final_polygonize as b where a.the_geom && b.the_geom and ST_intersects(a.the_geom, b.the_geom) AND a.${id_rsu} =b.${id_rsu}"""
                     finalMerge.add("SELECT * FROM $tmptableName")
                 } else if (entry.key.startsWith("building")) {
                     datasource."$entry.key".the_geom.createSpatialIndex()
-                    datasource."$entry.key".id_rsu.createIndex()
+                    datasource."$entry.key"."${id_rsu}".createIndex()
                     datasource """DROP TABLE IF EXISTS $tmptableName;
-                CREATE TABLE $tmptableName AS SELECT b.area, 0 as low_vegetation, 0 as high_vegetation, 0 as water, 0 as impervious, 0 as road, 1 as building, b.id, b.id_rsu from ${entry.key}  as a,
-                $final_polygonize as b where a.the_geom && b.the_geom and ST_intersects(a.the_geom, b.the_geom) AND a.ID_RSU =b.ID_RSU"""
+                CREATE TABLE $tmptableName AS SELECT b.area, 0 as low_vegetation, 0 as high_vegetation, 0 as water, 0 as impervious, 0 as road, 1 as building, b.${ID_COLUMN_NAME}, b.${id_rsu} from ${entry.key}  as a,
+                $final_polygonize as b where a.the_geom && b.the_geom and ST_intersects(a.the_geom, b.the_geom) AND a.${id_rsu} =b.${id_rsu}"""
                     finalMerge.add("SELECT * FROM $tmptableName")
                 }
             }
-
             if (finalMerge) {
                 //Do not drop RSU table
                 tablesToMerge.remove("$rsuTable")
                 def allInfoTableName = postfix "allInfoTableName"
                 datasource """DROP TABLE IF EXISTS $allInfoTableName, $tmp_point_polygonize, $final_polygonize, $tmp_tables, $outputTableName;
                                       CREATE TABLE $allInfoTableName as ${finalMerge.join(' union all ')};
-                                      CREATE INDEX ON $allInfoTableName USING BTREE(ID);
-                                      CREATE INDEX ON $allInfoTableName USING BTREE(ID_RSU);
+                                      CREATE INDEX ON $allInfoTableName (${ID_COLUMN_NAME});
+                                      CREATE INDEX ON $allInfoTableName (${id_rsu});
                                       CREATE TABLE $outputTableName AS SELECT MAX(AREA) AS AREA, MAX(LOW_VEGETATION) AS LOW_VEGETATION,
                                                         MAX(HIGH_VEGETATION) AS HIGH_VEGETATION, MAX(WATER) AS WATER,
                                                         MAX(IMPERVIOUS) AS IMPERVIOUS, MAX(ROAD) AS ROAD, 
-                                                        MAX(BUILDING) AS BUILDING, ID_RSU FROM $allInfoTableName GROUP BY ID, ID_RSU;
+                                                        MAX(BUILDING) AS BUILDING, ${id_rsu} FROM $allInfoTableName GROUP BY ${ID_COLUMN_NAME}, ${id_rsu};
                                       DROP TABLE IF EXISTS ${tablesToMerge.keySet().join(' , ')}, ${allInfoTableName}"""
             }
 
         } else {
-            error """Cannot compute any surface fraction statistics"""
+            error """Cannot compute the smallest geometries"""
         }
         [outputTableName: outputTableName]
     }
@@ -1417,6 +1422,7 @@ return create {
  * @param datasource A connexion to a database (H2GIS, PostGIS, ...) where are stored the input Table and in which
  * the resulting database will be stored
  * @param rsuTable The name of the input ITable where are stored the rsu geometries and the id_rsu
+ * @param id_rsu Name of the rsuTable column (unique identifier)
  * @param spatialRelationsTable The name of the table that stores all spatial relations (output of smallestCommunGeometry)
  * @param superpositions Map where are stored the overlaying layers as keys and the overlapped
  * layers as values. Note that the priority order for the overlapped layers is taken according to the priority variable
@@ -1437,12 +1443,12 @@ IProcess surfaceFractions() {
     return create {
         title "RSU surface fractions"
         id "surfaceFractions"
-        inputs rsuTable: String, spatialRelationsTable: String,
+        inputs rsuTable: String, id_rsu: "id_rsu", spatialRelationsTable: String,
                 superpositions: ["high_vegetation": ["water", "building", "low_vegetation", "road", "impervious"]],
                 priorities: ["water", "building", "high_vegetation", "low_vegetation", "road", "impervious"],
                 prefixName: String, datasource: JdbcDataSource
         outputs outputTableName: String
-        run { rsuTable, spatialRelationsTable, superpositions, priorities,
+        run { rsuTable, id_rsu, spatialRelationsTable, superpositions, priorities,
               prefixName, datasource ->
 
             def BASE_TABLE_NAME ="RSU_SURFACE_FRACTIONS"
@@ -1453,8 +1459,8 @@ IProcess surfaceFractions() {
             def outputTableName = postfix( BASE_TABLE_NAME)
 
             // Create the indexes on each of the input tables
-            datasource."$rsuTable".id_rsu.createIndex()
-            datasource."$spatialRelationsTable".id_rsu.createIndex()
+            datasource."$rsuTable"."$id_rsu".createIndex()
+            datasource."$spatialRelationsTable"."$id_rsu".createIndex()
             datasource."$spatialRelationsTable".water.createIndex()
             datasource."$spatialRelationsTable".road.createIndex()
             datasource."$spatialRelationsTable".impervious.createIndex()
@@ -1470,9 +1476,9 @@ IProcess surfaceFractions() {
                 i++
             }
 
-            def query = """DROP TABLE IF EXISTS $outputTableName; CREATE TABLE $outputTableName AS SELECT b.ID_RSU """
+            def query = """DROP TABLE IF EXISTS $outputTableName; CREATE TABLE $outputTableName AS SELECT b.${id_rsu} """
             def end_query = """ FROM $spatialRelationsTable AS a RIGHT JOIN $rsuTable b 
-                            ON a.ID_RSU=b.ID_RSU GROUP BY b.ID_RSU;"""
+                            ON a.${id_rsu}=b.${id_rsu} GROUP BY b.${id_rsu};"""
             // Calculates the fraction of overlapped layers according to "superpositionsWithPriorities"
             superpositions.each { key, values ->
                 // Calculating the overlaying layer when it has no overlapped layer

--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/SpatialUnits.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/SpatialUnits.groovy
@@ -44,6 +44,10 @@ IProcess createRSU() {
             // The name of the outputTableName is constructed
             def outputTableName = prefix prefixName, BASE_NAME
 
+            if(!inputTableName){
+                error "The input data to compute the RSU cannot be null or empty"
+                return null
+            }
             def epsg = datasource.getSpatialTable(inputTableName).srid
 
             if (area <= 0) {

--- a/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/BlockIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/BlockIndicatorsTests.groovy
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS.open
-import static org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager.load
 
 class BlockIndicatorsTests {
 

--- a/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/BuildingIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/BuildingIndicatorsTests.groovy
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS.open
-import static org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager.load
 
 class BuildingIndicatorsTests {
 

--- a/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/DataUtilsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/DataUtilsTests.groovy
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 import static org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS.open
-import static org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager.load
 
 class DataUtilsTests {
 

--- a/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/RsuIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/RsuIndicatorsTests.groovy
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS.open
-import static org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager.load
 
 class RsuIndicatorsTests {
 

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/OSMGISLayers.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/OSMGISLayers.groovy
@@ -110,16 +110,17 @@ IProcess extractAndCreateGISLayers() {
                 if (extract.execute(overpassQuery: query)) {
                     IProcess createGISLayerProcess = createGISLayers()
                     if (createGISLayerProcess.execute(datasource: datasource, osmFilePath: extract.results.outputFilePath, epsg: epsg)) {
-                        [buildingTableName    : createGISLayerProcess.getResults().buildingTableName,
-                         roadTableName        : createGISLayerProcess.getResults().roadTableName,
-                         railTableName        : createGISLayerProcess.getResults().railTableName,
-                         vegetationTableName  : createGISLayerProcess.getResults().vegetationTableName,
-                         hydroTableName       : createGISLayerProcess.getResults().hydroTableName,
-                         imperviousTableName  : createGISLayerProcess.getResults().imperviousTableName,
-                         urbanAreasTableName : createGISLayerProcess.getResults().urbanAreasTableName,
+                        def results =createGISLayerProcess.getResults();
+                        return [buildingTableName    : results.buildingTableName,
+                         roadTableName        : results.roadTableName,
+                         railTableName        : results.railTableName,
+                         vegetationTableName  : results.vegetationTableName,
+                         hydroTableName       : results.hydroTableName,
+                         imperviousTableName  : results.imperviousTableName,
+                         urbanAreasTableName : results.urbanAreasTableName,
                          zoneTableName        : outputZoneTable,
                          zoneEnvelopeTableName: outputZoneEnvelopeTable,
-                         coastlineTableName : createGISLayerProcess.getResults().coastlineTableName]
+                         coastlineTableName : results.coastlineTableName]
                     } else {
                         error "Cannot load the OSM file ${extract.results.outputFilePath}"
                     }

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/PrepareOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/PrepareOSM.groovy
@@ -54,7 +54,7 @@ IProcess buildGeoclimateLayers() {
                 def zoneTableName = res.zoneTableName
                 def zoneEnvelopeTableName = res.zoneEnvelopeTableName
                 def epsg = datasource.getSpatialTable(zoneTableName).srid
-                if (zoneTableName != null) {
+                if (zoneEnvelopeTableName != null) {
                     info "Formating OSM GIS layers"
                     IProcess format = OSM.formatBuildingLayer
                     format.execute([
@@ -109,7 +109,7 @@ IProcess buildGeoclimateLayers() {
 
                 }
 
-                [outputBuilding: buildingTableName, outputRoad: roadTableName,
+                return [outputBuilding: buildingTableName, outputRoad: roadTableName,
                  outputRail    : railTableName, outputHydro: hydroTableName,
                  outputVeget   : vegetationTableName, outputImpervious: imperviousTableName,
                  outputZone    : zoneTableName, outputZoneEnvelope: zoneEnvelopeTableName]

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/PrepareOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/PrepareOSM.groovy
@@ -37,7 +37,7 @@ IProcess buildGeoclimateLayers() {
             }
 
             info "Building OSM GIS layers"
-            IProcess process = processManager.OSMGISLayers.extractAndCreateGISLayers
+            IProcess process = OSM.extractAndCreateGISLayers
             if (process.execute([datasource: datasource, zoneToExtract: zoneToExtract,
                                  distance  : distance])) {
 
@@ -56,7 +56,7 @@ IProcess buildGeoclimateLayers() {
                 def epsg = datasource.getSpatialTable(zoneTableName).srid
                 if (zoneTableName != null) {
                     info "Formating OSM GIS layers"
-                    IProcess format = processManager.FormattingForAbstractModel.formatBuildingLayer
+                    IProcess format = OSM.formatBuildingLayer
                     format.execute([
                             datasource                : datasource,
                             inputTableName            : buildingTableName,
@@ -64,7 +64,7 @@ IProcess buildGeoclimateLayers() {
                             epsg                      : epsg])
                     buildingTableName = format.results.outputTableName
 
-                    format = processManager.FormattingForAbstractModel.formatRoadLayer
+                    format = OSM.formatRoadLayer
                     format.execute([
                             datasource                : datasource,
                             inputTableName            : roadTableName,
@@ -73,7 +73,7 @@ IProcess buildGeoclimateLayers() {
                     roadTableName = format.results.outputTableName
 
 
-                    format = processManager.FormattingForAbstractModel.formatRailsLayer
+                    format = OSM.formatRailsLayer
                     format.execute([
                             datasource                : datasource,
                             inputTableName            : railTableName,
@@ -81,7 +81,7 @@ IProcess buildGeoclimateLayers() {
                             epsg                      : epsg])
                     railTableName = format.results.outputTableName
 
-                    format = processManager.FormattingForAbstractModel.formatVegetationLayer
+                    format = OSM.formatVegetationLayer
                     format.execute([
                             datasource                : datasource,
                             inputTableName            : vegetationTableName,
@@ -89,7 +89,7 @@ IProcess buildGeoclimateLayers() {
                             epsg                      : epsg])
                     vegetationTableName = format.results.outputTableName
 
-                    format = processManager.FormattingForAbstractModel.formatHydroLayer
+                    format = OSM.formatHydroLayer
                     format.execute([
                             datasource                : datasource,
                             inputTableName            : hydroTableName,
@@ -97,7 +97,7 @@ IProcess buildGeoclimateLayers() {
                             epsg                      : epsg])
                     hydroTableName = format.results.outputTableName
 
-                    format = processManager.FormattingForAbstractModel.formatImperviousLayer
+                    format = OSM.formatImperviousLayer
                     format.execute([
                             datasource                : datasource,
                             inputTableName            : imperviousTableName,

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
@@ -594,6 +594,7 @@ IProcess osm_processing() {
                                             hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName,
                                             rsu_lcz:results.outputTableRsuLcz,
                                             rsu_urban_typo_area:results.outputTableRsuUrbanTypoArea,
+                                            rsu_urban_typo_floor_area:results.outputTableRsuUrbanTypoFloorArea,
                                             prefixName: processing_parameters.prefixName
                                     )){
                                         results.put("grid_indicators", rasterizedIndicators.results.outputTableName)

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
@@ -16,7 +16,6 @@ import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 import org.orbisgis.orbisdata.datamanager.jdbc.postgis.POSTGIS
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisprocess.geoclimate.geoindicators.Geoindicators
 import org.orbisgis.orbisprocess.geoclimate.processingchain.ProcessingChain
 import org.orbisgis.orbisanalysis.osm.OSMTools
 
@@ -67,9 +66,10 @@ import java.sql.SQLException
  *  *     ,
  *  *   [OPTIONAL ENTRY]  "parameters":
  *  *     {"distance" : 1000,
+ *  *         "prefixName": "",
+ *  *        rsu_indicators:{
  *  *         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
  *  *         "svfSimplified": false,
- *  *         "prefixName": "",
  *  *         "mapOfWeights":
  *  *         {"sky_view_factor": 1,
  *  *             "aspect_ratio": 1,
@@ -81,6 +81,7 @@ import java.sql.SQLException
  *  *         "hLevMin": 3,
  *  *         "hLevMax": 15,
  *  *         "hThresho2": 10
+ *          }
  *  *     }
  *  *     }
  *  The parameters entry tag contains all geoclimate chain parameters.
@@ -209,7 +210,8 @@ IProcess workflow() {
                                                     "urban_areas",
                                                     "rsu_urban_typo_area",
                                                     "rsu_urban_typo_floor_area",
-                                                    "building_urban_typo"]
+                                                    "building_urban_typo",
+                                                    "grid_indicators"]
                         //Get processing parameters
                         def processing_parameters = extractProcessingParameters(parameters.get("parameters"))
                         if(!processing_parameters){
@@ -460,6 +462,9 @@ IProcess osm_processing() {
                         IProcess createGISLayerProcess = OSM.createGISLayers
                         if (createGISLayerProcess.execute(datasource: h2gis_datasource, osmFilePath: extract.results.outputFilePath, epsg: srid)) {
                             def gisLayersResults = createGISLayerProcess.getResults()
+                            def rsu_indicators_params = processing_parameters.rsu_indicators
+                            def grid_indicators_params = processing_parameters.grid_indicators
+
                             info "Formating OSM GIS layers"
                             //Format urban areas
                             IProcess format = OSM.formatUrbanAreas
@@ -470,7 +475,6 @@ IProcess osm_processing() {
                                     epsg                      : srid])
                             def urbanAreasTable = format.results.outputTableName
 
-                            def estimateHeight = processing_parameters."estimateHeight"
                             format = OSM.formatBuildingLayer
                             format.execute([
                                     datasource                : h2gis_datasource,
@@ -533,7 +537,7 @@ IProcess osm_processing() {
 
                             def seaLandMaskTableName = format.results.outputTableName
 
-                            //Sea/Land mask
+                            //Merge the Sea/Land mask with water tabke
                             format = OSM.mergeWaterAndSeaLandTables
                             format.execute([
                                     datasource           : h2gis_datasource,
@@ -544,56 +548,65 @@ IProcess osm_processing() {
 
                             info "OSM GIS layers formated"
 
-                            //Compute the indicators
-                            IProcess geoIndicators = ProcessingChain.GeoIndicatorsChain.computeAllGeoIndicators()
-                            if (!geoIndicators.execute(datasource: h2gis_datasource, zoneTable: zoneTableName,
-                                    buildingTable: buildingTableName, roadTable: roadTableName,
-                                    railTable: railTableName, vegetationTable: vegetationTableName,
-                                    hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName,
-                                    buildingEstimateTableName: buildingEstimateTableName,
-                                    surface_vegetation: processing_parameters.surface_vegetation,
-                                    surface_hydro: processing_parameters.surface_hydro,
-                                    snappingTolerance: processing_parameters.snappingTolerance,
-                                    indicatorUse: processing_parameters.indicatorUse,
-                                    svfSimplified: processing_parameters.svfSimplified,
-                                    prefixName: processing_parameters.prefixName,
-                                    mapOfWeights: processing_parameters.mapOfWeights,
-                                    urbanTypoModelName: "URBAN_TYPOLOGY_OSM_RF_2_1.model",
-                                    buildingHeightModelName: estimateHeight ? "BUILDING_HEIGHT_OSM_RF_2_0.model" : "")) {
-                                error "Cannot build the geoindicators for the zone $id_zone"
-                            } else {
-                                def results = geoIndicators.getResults()
-                                results.put("buildingTableName", buildingTableName)
-                                results.put("roadTableName", roadTableName)
-                                results.put("railTableName", railTableName)
-                                results.put("hydrographicTableName", hydrographicTableName)
-                                results.put("vegetationTableName", vegetationTableName)
-                                results.put("imperviousTableName", imperviousTableName)
-                                results.put("urbanAreasTableName", urbanAreasTable)
+                            //Add the GIS layers to the list of results
+                            def results = [:]
+                            results.put("buildingTableName", buildingTableName)
+                            results.put("roadTableName", roadTableName)
+                            results.put("railTableName", railTableName)
+                            results.put("hydrographicTableName", hydrographicTableName)
+                            results.put("vegetationTableName", vegetationTableName)
+                            results.put("imperviousTableName", imperviousTableName)
+                            results.put("urbanAreasTableName", urbanAreasTable)
 
-                                //Compute the indicator at grid scale if specified
-                                def  grid_indicators = processing_parameters.grid_indicators
-                                if(grid_indicators){
-                                    def x_size = grid_indicators.x_size
-                                    def y_size = grid_indicators.y_size
+                            //Compute the RSU indicators
+                            if(rsu_indicators_params){
+                                def estimateHeight  = rsu_indicators_params."estimateHeight"
+                                IProcess geoIndicators = ProcessingChain.GeoIndicatorsChain.computeAllGeoIndicators()
+                                if (!geoIndicators.execute(datasource: h2gis_datasource, zoneTable: zoneTableName,
+                                        buildingTable: buildingTableName, roadTable: roadTableName,
+                                        railTable: railTableName, vegetationTable: vegetationTableName,
+                                        hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName,
+                                        buildingEstimateTableName: buildingEstimateTableName,
+                                        surface_vegetation: rsu_indicators_params.surface_vegetation,
+                                        surface_hydro: rsu_indicators_params.surface_hydro,
+                                        snappingTolerance: rsu_indicators_params.snappingTolerance,
+                                        indicatorUse: rsu_indicators_params.indicatorUse,
+                                        svfSimplified: rsu_indicators_params.svfSimplified,
+                                        prefixName: processing_parameters.prefixName,
+                                        mapOfWeights: rsu_indicators_params.mapOfWeights,
+                                        urbanTypoModelName: "URBAN_TYPOLOGY_OSM_RF_2_1.model",
+                                        buildingHeightModelName: estimateHeight ? "BUILDING_HEIGHT_OSM_RF_2_0.model" : "")) {
+                                    error "Cannot build the geoindicators for the zone $id_zone"
+                                }
+                                else{
+                                     results.putAll(geoIndicators.getResults())
+                                }
+                            }
+
+                            //Compute the grid indicators
+                            if(grid_indicators_params){
+                                    def x_size = grid_indicators_params.x_size
+                                    def y_size = grid_indicators_params.y_size
                                     IProcess rasterizedIndicators =  ProcessingChain.GeoIndicatorsChain.rasterizeIndicators()
                                     if(rasterizedIndicators.execute(datasource:h2gis_datasource,zoneEnvelopeTableName: zoneEnvelopeTableName,
-                                            x_size : x_size, y_size : y_size,list_indicators :grid_indicators.indicators,
+                                            x_size : x_size, y_size : y_size,list_indicators :grid_indicators_params.indicators,
                                             buildingTable: buildingTableName, roadTable: roadTableName, vegetationTable: vegetationTableName,
-                                            hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName, rsu_lcz:results.outputTableRsuLcz, rsu_urban_typo:"",
+                                            hydrographicTable: hydrographicTableName, imperviousTable: imperviousTableName,
+                                            rsu_lcz:results.outputTableRsuLcz,
+                                            rsu_urban_typo_area:results.outputTableRsuUrbanTypoArea,
                                             prefixName: processing_parameters.prefixName
                                     )){
                                         results.put("grid_indicators", rasterizedIndicators.results.outputTableName)
                                         ouputTableFiles<<rasterizedIndicators.results.outputTableName
                                     }
-                                }
+                            }
+
                             if (outputFolder  && ouputTableFiles) {
                                 saveOutputFiles(h2gis_datasource, id_zone, results, ouputTableFiles, outputFolder, "osm_", outputSRID, reproject, deleteOutputData)
                             }
                             if (output_datasource) {
                                 saveTablesInDatabase(output_datasource, h2gis_datasource, outputTableNames, results, id_zone, srid, outputSRID, reproject)
                             }
-                        }
 
                         } else {
                             error "Cannot load the OSM file ${extract.results.outputFilePath}"
@@ -875,81 +888,92 @@ def findIDZones(def h2gis_datasource, def id_zones){
  * @return a filled map of parameters
  */
 def extractProcessingParameters(def processing_parameters){
-    def defaultParameters = [distance: 0,indicatorUse: ["LCZ", "URBAN_TYPOLOGY", "TEB"],
-                             svfSimplified:false, prefixName: "",
-                             surface_vegetation: 10000,
-                             surface_hydro: 2500,
-                             snappingTolerance :0.01,
-                             mapOfWeights :  ["sky_view_factor"                : 4,
-                                              "aspect_ratio"                   : 3,
-                                              "building_surface_fraction"      : 8,
-                                              "impervious_surface_fraction"    : 0,
-                                              "pervious_surface_fraction"      : 0,
-                                              "height_of_roughness_elements"   : 6,
-                                              "terrain_roughness_length"       : 0.5],
-                             hLevMin : 3, hLevMax: 15, hThresholdLev2: 10,
-                             estimateHeight:false,
-                             lczModelName: "LCZ_OSM_RF_1_0.model",
-                             urbanTypoModelName: "URBAN_TYPOLOGY_OSM_RF_2_0.model"]
+    def defaultParameters = [distance: 0, prefixName: ""]
     if(processing_parameters){
         def distanceP =  processing_parameters.distance
         if(distanceP && distanceP in Number){
             defaultParameters.distance = distanceP
         }
-        def indicatorUseP = processing_parameters.indicatorUse
-        if(indicatorUseP && indicatorUseP in List){
-            defaultParameters.indicatorUse = indicatorUseP
-        }
-
-        def snappingToleranceP =  processing_parameters.snappingTolerance
-        if(snappingToleranceP && snappingToleranceP in Number){
-            defaultParameters.snappingTolerance = snappingToleranceP
-        }
-
-        def surface_vegetationP =  processing_parameters.surface_vegetation
-        if(surface_vegetationP && surface_vegetationP in Number){
-            defaultParameters.surface_vegetation = surface_vegetationP
-        }
-        def surface_hydroP =  processing_parameters.surface_hydro
-        if(surface_hydroP && surface_hydroP in Number){
-            defaultParameters.surface_hydro = surface_hydroP
-        }
-
-        def svfSimplifiedP = processing_parameters.svfSimplified
-        if(svfSimplifiedP && svfSimplifiedP in Boolean){
-            defaultParameters.svfSimplified = svfSimplifiedP
-        }
         def prefixNameP = processing_parameters.prefixName
         if(prefixNameP && prefixNameP in String){
             defaultParameters.prefixName = prefixNameP
         }
-
-        def mapOfWeightsP = processing_parameters.mapOfWeights
-        if(mapOfWeightsP && mapOfWeightsP in Map){
-            def defaultmapOfWeights = defaultParameters.mapOfWeights
-            if((defaultmapOfWeights+mapOfWeightsP).size()!=defaultmapOfWeights.size()){
-                error "The number of mapOfWeights parameters must contain exactly the parameters ${defaultmapOfWeights.keySet().join(",")}"
-                return
+        //Check for rsu indicators
+        def  rsu_indicators = processing_parameters.rsu_indicators
+        if(rsu_indicators){
+            def rsu_indicators_default =[indicatorUse: [],
+                                         svfSimplified:false,
+                                         surface_vegetation: 10000,
+                                         surface_hydro: 2500,
+                                         snappingTolerance :0.01,
+                                         mapOfWeights :  ["sky_view_factor"                : 4,
+                                                          "aspect_ratio"                   : 3,
+                                                          "building_surface_fraction"      : 8,
+                                                          "impervious_surface_fraction"    : 0,
+                                                          "pervious_surface_fraction"      : 0,
+                                                          "height_of_roughness_elements"   : 6,
+                                                          "terrain_roughness_length"       : 0.5],
+                                         hLevMin : 3, hLevMax: 15, hThresholdLev2: 10,
+                                         estimateHeight:false,
+                                         urbanTypoModelName: "URBAN_TYPOLOGY_OSM_RF_2_0.model"]
+            def indicatorUseP = rsu_indicators.indicatorUse
+            if(indicatorUseP && indicatorUseP in List) {
+                def allowed_rsu_indicators = ["LCZ", "URBAN_TYPOLOGY", "TEB"]
+                def allowedOutputRSUIndicators = allowed_rsu_indicators.intersect(indicatorUseP*.toUpperCase())
+                if (allowedOutputRSUIndicators) {
+                    rsu_indicators_default.indicatorUse = indicatorUseP
+                }
+                else {
+                    info "Please set a valid list of RSU indicator names in ${allowedOutputRSUIndicators}"
+                    return
+                }
             }else{
-                defaultParameters.mapOfWeights = mapOfWeightsP
+                info "The list of RSU indicator names cannot be null or empty"
+                return
             }
-        }
-
-        def hLevMinP =  processing_parameters.hLevMin
-        if(hLevMinP && hLevMinP in Integer){
-            defaultParameters.hLevMin = hLevMinP
-        }
-        def hLevMaxP =  processing_parameters.hLevMax
-        if(hLevMaxP && hLevMaxP in Integer){
-            defaultParameters.hLevMax = hLevMaxP
-        }
-        def hThresholdLev2P =  processing_parameters.hThresholdLev2
-        if(hThresholdLev2P && hThresholdLev2P in Integer){
-            defaultParameters.hThresholdLev2 = hThresholdLev2P
-        }
-        def estimateHeight = processing_parameters.estimateHeight
-        if(estimateHeight && estimateHeight in Boolean){
-            defaultParameters.estimateHeight = estimateHeight
+            def snappingToleranceP =  rsu_indicators.snappingTolerance
+            if(snappingToleranceP && snappingToleranceP in Number){
+                rsu_indicators_default.snappingTolerance = snappingToleranceP
+            }
+            def surface_vegetationP =  rsu_indicators.surface_vegetation
+            if(surface_vegetationP && surface_vegetationP in Number){
+                rsu_indicators_default.surface_vegetation = surface_vegetationP
+            }
+            def surface_hydroP =  rsu_indicators.surface_hydro
+            if(surface_hydroP && surface_hydroP in Number){
+                rsu_indicators_default.surface_hydro = surface_hydroP
+            }
+            def svfSimplifiedP = rsu_indicators.svfSimplified
+            if(svfSimplifiedP && svfSimplifiedP in Boolean){
+                rsu_indicators_default.svfSimplified = svfSimplifiedP
+            }
+            def hLevMinP =  rsu_indicators.hLevMin
+            if(hLevMinP && hLevMinP in Integer){
+                rsu_indicators_default.hLevMin = hLevMinP
+            }
+            def hLevMaxP =  rsu_indicators.hLevMax
+            if(hLevMaxP && hLevMaxP in Integer){
+                rsu_indicators_default.hLevMax = hLevMaxP
+            }
+            def hThresholdLev2P =  rsu_indicators.hThresholdLev2
+            if(hThresholdLev2P && hThresholdLev2P in Integer){
+                rsu_indicators_default.hThresholdLev2 = hThresholdLev2P
+            }
+            def estimateHeight = rsu_indicators.estimateHeight
+            if(estimateHeight && estimateHeight in Boolean){
+                rsu_indicators_default.estimateHeight = estimateHeight
+            }
+            def mapOfWeightsP = rsu_indicators.mapOfWeights
+            if(mapOfWeightsP && mapOfWeightsP in Map){
+                def defaultmapOfWeights = rsu_indicators_default.mapOfWeights
+                if((defaultmapOfWeights+mapOfWeightsP).size()!=defaultmapOfWeights.size()){
+                    error "The number of mapOfWeights parameters must contain exactly the parameters ${defaultmapOfWeights.keySet().join(",")}"
+                    return
+                }else{
+                    rsu_indicators_default.mapOfWeights = mapOfWeightsP
+                }
+            }
+            defaultParameters.put("rsu_indicators", rsu_indicators_default)
         }
 
         //Check for grid indicators
@@ -967,8 +991,8 @@ def extractProcessingParameters(def processing_parameters){
                     info "The list of indicator names cannot be null or empty"
                     return
                 }
-                def allowed_grid_indicators=["BUILDING_AREA","BUILDING_HEIGHT_AVG","WATER_AREA","VEGETATION_AREA",
-                          "ROAD_AREA", "IMPERVIOUS_AREA", "RSU_URBAN_TYPO", "RSU_LCZ"]
+                def allowed_grid_indicators=["BUILDING_FRACTION","BUILDING_HEIGHT", "WATER_FRACTION","VEGETATION_FRACTION",
+                          "ROAD_FRACTION", "IMPERVIOUS_FRACTION", "RSU_URBAN_TYPO_FRACTION", "RSU_LCZ_FRACTION"]
                 def allowedOutputIndicators = allowed_grid_indicators.intersect(list_indicators*.toUpperCase())
                 if(allowedOutputIndicators){
                 def grid_indicators_tmp =  [
@@ -1120,6 +1144,10 @@ def saveTablesInDatabase(JdbcDataSource output_datasource, JdbcDataSource h2gis_
 
     //Export rsu_urban_typo_floor_area
     indicatorTableBatchExportTable(output_datasource, outputTableNames.rsu_urban_typo_floor_area,id_zone,h2gis_datasource, h2gis_tables.outputTableRsuUrbanTypoFloorArea
+            , "",inputSRID,outputSRID,reproject)
+
+    //Export grid_indicators
+    indicatorTableBatchExportTable(output_datasource, outputTableNames.grid_indicators,id_zone,h2gis_datasource, h2gis_tables.grid_indicators
             , "",inputSRID,outputSRID,reproject)
 
     //Export building_urban_typo

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
@@ -481,8 +481,8 @@ IProcess osm_processing() {
                                     inputTableName            : gisLayersResults.buildingTableName,
                                     inputZoneEnvelopeTableName: zoneEnvelopeTableName,
                                     epsg                      : srid,
-                                    h_lev_min                 : processing_parameters.h_lev_min,
-                                    h_lev_max                 : processing_parameters.h_lev_max,
+                                    h_lev_min                 : processing_parameters.hLevMin,
+                                    h_lev_max                 : processing_parameters.hLevMax,
                                     hThresholdLev2            : processing_parameters.hThresholdLev2,
                                     urbanAreasTableName       : urbanAreasTable])
 

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.orbisgis.orbisdata.processmanager.process.GroovyProcessManager
 
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotNull

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -541,6 +541,40 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
     }
 
+    @Disabled
+    @Test
+    void testGrid_Indicators() {
+        String directory ="./target/geoclimate_chain_estimated_height"
+        File dirFile = new File(directory)
+        dirFile.delete()
+        dirFile.mkdir()
+        def osm_parmeters = [
+                "description" :"Example of configuration file to run the OSM workflow and store the results in a folder",
+                "geoclimatedb" : [
+                        "folder" : "${dirFile.absolutePath}",
+                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete" :true
+                ],
+                "input" : [
+                        "osm" : ["Pont de Veyle"]],
+                "output" :[
+                        "folder" : "$directory"],
+                "parameters":
+                        ["distance" : 0,
+                         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY"],
+                         "svfSimplified": true,
+                         "prefixName": "",
+                         "estimateHeight":true,
+                         "grid_indicators": [
+                             "x_size": 1000,
+                             "y_size": 1000,
+                             "indicators": ["RSU_LCZ"]
+                         ]
+                        ]
+        ]
+        IProcess process = OSM.workflow
+        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+    }
 
     @Disabled
     @Test

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -4,6 +4,7 @@ import groovy.json.JsonOutput
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
+import org.orbisgis.orbisdata.datamanager.jdbc.postgis.POSTGIS
 import org.orbisgis.orbisdata.processmanager.api.IProcess
 import org.orbisgis.orbisprocess.geoclimate.geoindicators.Geoindicators
 import org.orbisgis.orbisprocess.geoclimate.processingchain.ProcessingChain
@@ -12,16 +13,15 @@ import static org.junit.jupiter.api.Assertions.*
 
 class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
-    @Disabled
     @Test
     void osmToRSU() {
-        String directory ="./target/osm_processchain_geoindicators"
+        String directory ="./target/osm_processchain_geoindicators_rsu"
 
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def h2GIS = H2GIS.open(dirFile.absolutePath+File.separator+'osm_chain_db;AUTO_SERVER=TRUE')
-        def zoneToExtract = "Pont de veyle"
+        def zoneToExtract = "Pont-de-Veyle"
         IProcess process = OSM.buildGeoclimateLayers
 
         process.execute([datasource: h2GIS, zoneToExtract :zoneToExtract, distance: 0])
@@ -47,7 +47,9 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                             inputTableName: prepareRSUData.results.outputTableName,
                             inputZoneTableName :process.getResults().outputZone,
                             prefixName    : prefixName])) {
-                h2GIS.getTable(createRSU.results.outputTableName).save(dirFile.absolutePath+File.separator+"${prefixName}.geojson", true)
+                //TODO enable it for debug purpose
+                // h2GIS.getTable(createRSU.results.outputTableName).save(dirFile.absolutePath+File.separator+"${prefixName}.geojson", true)
+                assertTrue(h2GIS.getTable(createRSU.results.outputTableName).getRowCount()>0)
             }
         }
     }
@@ -61,11 +63,12 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         String urlHydro = new File(getClass().getResource("HYDRO.geojson").toURI()).absolutePath
         String urlZone = new File(getClass().getResource("ZONE.geojson").toURI()).absolutePath
 
-        boolean saveResults = true
-        String directory ="./target/osm_processchain_geoindicators"
+        //TODO enable it for debug purpose
+        boolean saveResults = false
+        String directory ="./target/osm_processchain_geoindicators_redon"
         def prefixName = ""
         def indicatorUse = ["URBAN_TYPOLOGY", "LCZ", "TEB"]
-        def svfSimplified = false
+        def svfSimplified = true
 
         File dirFile = new File(directory)
         dirFile.delete()
@@ -94,14 +97,13 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
     }
 
-    @Disabled
     @Test
     void osmGeoIndicatorsFromApi() {
         String directory ="./target/osm_processchain_indicators"
-        boolean saveResults = true
+        //TODO enable it for debug purpose
+        boolean saveResults = false
         def prefixName = ""
-        def svfSimplified = false
-
+        def svfSimplified = true
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
@@ -109,7 +111,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         H2GIS datasource = H2GIS.open(dirFile.absolutePath+File.separator+"osm_chain_db;AUTO_SERVER=TRUE")
 
         //Extract and transform OSM data
-        def zoneToExtract = "Pont de veyle"
+        def zoneToExtract = "Pont-de-Veyle"
 
         IProcess prepareOSMData = OSM.buildGeoclimateLayers
 
@@ -154,7 +156,8 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         String urlHydro = new File(getClass().getResource("HYDRO.geojson").toURI()).absolutePath
         String urlZone = new File(getClass().getResource("ZONE.geojson").toURI()).absolutePath
 
-        boolean saveResults = true
+        //TODO enable it for debug purpose
+        boolean saveResults = false
         String directory ="./target/osm_processchain_lcz"
 
         File dirFile = new File(directory)
@@ -186,65 +189,67 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                 buildingTable: buildingTableName, roadTable: roadTableName,
                 railTable: railTableName, vegetationTable: vegetationTableName,
                 hydrographicTable: hydrographicTableName, indicatorUse: ["LCZ"],
-                mapOfWeights: mapOfWeights,lczRandomForest: false )
+                mapOfWeights: mapOfWeights,svfSimplified: true )
         assertTrue(datasource.getTable(geodindicators.results.outputTableBuildingIndicators).rowCount>0)
         assertNotNull(geodindicators.results.outputTableBlockIndicators)
         assertTrue(datasource.getTable(geodindicators.results.outputTableRsuIndicators).rowCount>0)
         assertTrue(datasource.getTable(geodindicators.results.outputTableRsuLcz).rowCount>0)
     }
 
-    @Disabled
     @Test
     void osmWorkflowToH2Database() {
-        String directory ="./target/geoclimate_chain"
+        String directory ="./target/geoclimate_chain_db"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "description" :"Example of configuration file to run the OSM workflow and store the result into a database",
                 "geoclimatedb" : [
                         "folder" : "${dirFile.absolutePath}",
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                        "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["romainville"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
                         "database" :
                                 ["user" : "sa",
-                                "password":"sa",
+                                "password":"",
                                  "url": "jdbc:h2://${dirFile.absolutePath+File.separator+"geoclimate_chain_db_output;AUTO_SERVER=TRUE"}",
-                                 "tables": ["building_indicators":"building_indicators",
-                                          "block_indicators":"block_indicators",
+                                 "tables": [
                                           "rsu_indicators":"rsu_indicators",
-                                          "rsu_lcz":"rsu_lcz",
-                                          "zones":"zones" ]]],
+                                          "rsu_lcz":"rsu_lcz" ]]],
                 "parameters":
                         ["distance" : 0,
-                         "indicatorUse": ["LCZ", "TEB", "URBAN_TYPOLOGY"],
-                         "svfSimplified": true,
-                         "prefixName": "",
-                         "mapOfWeights":
-                                 ["sky_view_factor": 1,
-                                  "aspect_ratio": 1,
-                                  "building_surface_fraction": 1,
-                                  "impervious_surface_fraction" : 1,
-                                  "pervious_surface_fraction": 1,
-                                  "height_of_roughness_elements": 1,
-                                  "terrain_roughness_length": 1],
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10
+                         rsu_indicators: ["indicatorUse": ["LCZ"],
+                                          "svfSimplified": true,
+                                          "mapOfWeights":
+                                                  ["sky_view_factor": 1,
+                                                   "aspect_ratio": 1,
+                                                   "building_surface_fraction": 1,
+                                                   "impervious_surface_fraction" : 1,
+                                                   "pervious_surface_fraction": 1,
+                                                   "height_of_roughness_elements": 1,
+                                                   "terrain_roughness_length": 1],
+                                          "hLevMin": 3,
+                                          "hLevMax": 15,
+                                          "hThresholdLev2": 10],
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        H2GIS outputdb = H2GIS.open(dirFile.absolutePath+File.separator+"geoclimate_chain_db_output;AUTO_SERVER=TRUE")
+        def rsu_indicatorsTable = outputdb.getTable("rsu_indicators")
+        assertNotNull(rsu_indicatorsTable)
+        assertTrue(rsu_indicatorsTable.getRowCount()>0)
+        def rsu_lczTable = outputdb.getTable("rsu_lcz")
+        assertNotNull(rsu_lczTable)
+        assertTrue(rsu_lczTable.getRowCount()>0)
     }
 
-    @Disabled
     @Test
     void osmWorkflowToPostGISDatabase() {
-        String directory ="./target/geoclimate_chain"
+        String directory ="./target/geoclimate_chain_postgis"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
@@ -256,40 +261,43 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["romainville"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
                         "database" :
                                 ["user" : "orbisgis",
                                  "password":"orbisgis",
                                  "url": "jdbc:postgresql://localhost:5432/orbisgis_db",
-                                 "tables": ["building_indicators":"building_indicators",
-                                            "block_indicators":"block_indicators",
+                                 "tables": [
                                             "rsu_indicators":"rsu_indicators",
                                             "rsu_lcz":"rsu_lcz",
                                             "zones":"zones" ]]],
                 "parameters":
                         ["distance" : 0,
-                         "indicatorUse": ["LCZ", "TEB", "URBAN_TYPOLOGY"],
-                         "svfSimplified": true,
-                         "prefixName": "",
-                         "mapOfWeights":
-                                 ["sky_view_factor": 1,
-                                  "aspect_ratio": 1,
-                                  "building_surface_fraction": 1,
-                                  "impervious_surface_fraction" : 1,
-                                  "pervious_surface_fraction": 1,
-                                  "height_of_roughness_elements": 1,
-                                  "terrain_roughness_length": 1  ],
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10
+                         rsu_indicators: ["indicatorUse": ["LCZ"],
+                                          "svfSimplified": true]
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        def postgis_dbProperties = [databaseName: 'orbisgis_db',
+                                           user        : 'orbisgis',
+                                           password    : 'orbisgis',
+                                           url         : 'jdbc:postgresql://localhost:5432/'
+        ]
+        POSTGIS postgis = POSTGIS.open(postgis_dbProperties);
+        if(postgis){
+            def rsu_indicatorsTable = postgis.getTable("rsu_indicators")
+            assertNotNull(rsu_indicatorsTable)
+            assertTrue(rsu_indicatorsTable.getRowCount()>0)
+            def rsu_lczTable = postgis.getTable("rsu_lcz")
+            assertNotNull(rsu_lczTable)
+            assertTrue(rsu_lczTable.getRowCount()>0)
+            def zonesTable = postgis.getTable("rsu_lcz")
+            assertNotNull(zonesTable)
+            assertTrue(zonesTable.getRowCount()>0)
+        }
     }
 
-    @Disabled
     @Test
     void testOSMWorkflowFromPlaceNameWithSrid() {
         String directory ="./target/geoclimate_chain_srid"
@@ -297,32 +305,28 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "description" :"Example of configuration file to run the OSM workflow and store the results in a folder",
                 "geoclimatedb" : [
                         "folder" : "${dirFile.absolutePath}",
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-veyle"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : "${directory}",
                         "srid":"4326"],
                 "parameters":
                         ["distance" : 0,
-                         "indicatorUse": ["LCZ"],
-                         "svfSimplified": true,
-                         "prefixName": "",
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10
+                         rsu_indicators: ["indicatorUse": ["LCZ"],
+                                          "svfSimplified": true]
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
         //Test the SRID of all output files
         def geoFiles = []
-        def  folder = new File("${directory+File.separator}osm_Pont-de-veyle")
+        def  folder = new File("${directory+File.separator}osm_Pont-de-Veyle")
         folder.eachFileRecurse groovy.io.FileType.FILES,  { file ->
             if (file.name.toLowerCase().endsWith(".geojson")) {
                 geoFiles << file.getAbsolutePath()
@@ -335,7 +339,6 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         }
     }
 
-    @Disabled
     @Test
     void testOSMWorkflowFromPlaceName() {
         String directory ="./target/geoclimate_chain"
@@ -350,12 +353,12 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Brest"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : "$directory"],
                 "parameters":
-                        [ "indicatorUse": ["LCZ"],
-                         "svfSimplified": true
+                        [rsu_indicators: ["indicatorUse": ["LCZ"],
+                                          "svfSimplified": true]
                         ]
         ]
         IProcess process = OSM.workflow
@@ -386,7 +389,6 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
     }
 
-    @Disabled
     @Test
     void testOSMWorkflowFromBbox() {
         String directory ="./target/geoclimate_chain"
@@ -445,14 +447,13 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Pont de veyle"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : "$directory"],
                 "parameters":
                         ["distance" : 100,
-                         "indicatorUse": ["LCZ"],
-                         "svfSimplified": true,
-                         "prefixName": "",
+                         rsu_indicators: ["indicatorUse": ["LCZ"],
+                                          "svfSimplified": true,
                          "mapOfWeights":
                                  ["sky_view_factor": 1,
                                   "aspect_ratio": 1,
@@ -464,51 +465,11 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                                   "terrain_roughness_class": 1 ],
                          "hLevMin": 3,
                          "hLevMax": 15,
-                         "hThresholdLev2": 10
+                         "hThresholdLev2": 10]
                         ]
         ]
         IProcess process = OSM.workflow
         assertFalse(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
-    }
-
-    @Disabled
-    @Test
-    void testOSMLCZ() {
-        String directory ="./target/geoclimate_chain"
-        File dirFile = new File(directory)
-        dirFile.delete()
-        dirFile.mkdir()
-        def osm_parmeters = [
-            "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
-            "geoclimatedb" : [
-                    "folder" : "${dirFile.absolutePath}",
-                    "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                    "delete" :true
-            ],
-            "input" : [
-                "osm" : ["Pont de veyle"]],
-            "output" :[
-                "folder" : "$directory"],
-            "parameters":
-            ["distance" : 100,
-                "indicatorUse": ["LCZ"],
-                "svfSimplified": true,
-                "prefixName": "",
-                "mapOfWeights":
-                ["sky_view_factor": 1,
-                    "aspect_ratio": 1,
-                    "building_surface_fraction": 1,
-                    "impervious_surface_fraction" : 1,
-                    "pervious_surface_fraction": 1,
-                    "height_of_roughness_elements": 1,
-                    "terrain_roughness_length": 1  ],
-                "hLevMin": 3,
-                "hLevMax": 15,
-                "hThresholdLev2": 10
-            ]
-        ]
-        IProcess process = OSM.workflow
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
     }
 
     @Disabled
@@ -526,22 +487,21 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Vannes"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : "$directory"],
                 "parameters":
                         ["distance" : 0,
-                         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY"],
+                         rsu_indicators: ["indicatorUse": ["LCZ", "URBAN_TYPOLOGY"],
                          "svfSimplified": true,
-                         "prefixName": "",
-                         "estimateHeight":true
+                         "estimateHeight":true]
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
     }
 
-    @Disabled
+
     @Test
     void testGrid_Indicators() {
         String directory ="./target/geoclimate_chain_grid"
@@ -556,24 +516,27 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Pont de Veyle"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : "$directory"],
+                "folder" : ["path": "$directory",
+                    "tables": ["grid_indicators"]]],
                 "parameters":
                         ["distance" : 0,
-                         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY"],
-                         "svfSimplified": true,
-                         "prefixName": "",
-                         "estimateHeight":true,
                          "grid_indicators": [
                              "x_size": 100,
                              "y_size": 100,
-                             "indicators": ["RSU_LCZ", "WATER_AREA"]
+                             "indicators": ["WATER_FRACTION"]
                          ]
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        def  grid_file = new File(directory+File.separator+"osm_Pont-de-Veyle" +File.separator+"grid_indicators.geojson")
+        assertTrue(grid_file.exists())
+        H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
+        h2gis.load(grid_file, "grid_file")
+        assertTrue h2gis.firstRow("select count(*) as count from grid_file where water_fraction>0").count>0
+
     }
 
     @Disabled
@@ -591,12 +554,13 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Pont de veyle"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : "$directory"],
                 "parameters":
-                        ["distance" : 1000,
-                         "svfSimplified": false,
+                        ["distance" : 0,
+                         rsu_indicators:[
+                         "svfSimplified": true,
                          "prefixName": "",
                          "mapOfWeights":
                                  ["sky_view_factor": 1,
@@ -608,7 +572,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                                   "terrain_roughness_length": 1  ],
                          "hLevMin": 3,
                          "hLevMax": 15,
-                         "hThresholdLev2": 10
+                         "hThresholdLev2": 10]
                         ]
         ]
         IProcess process = OSM.workflow
@@ -629,25 +593,15 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Pont de veyle"]],
+                        "osm" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : "$directory"],
                 "parameters":
                         [
-                         "indicatorUse": ["TEB"],
-                         "svfSimplified": true,
-                         "prefixName": "",
-                         "mapOfWeights":
-                                 ["sky_view_factor": 1,
-                                  "aspect_ratio": 1,
-                                  "building_surface_fraction": 1,
-                                  "impervious_surface_fraction" : 1,
-                                  "pervious_surface_fraction": 1,
-                                  "height_of_roughness_elements": 1,
-                                  "terrain_roughness_length": 1  ],
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10
+                                rsu_indicators:[
+                                        "indicatorUse": ["TEB"],
+                                        "svfSimplified": true
+                                ]
                         ]
         ]
         IProcess process = OSM.workflow

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -230,10 +230,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                                                    "impervious_surface_fraction" : 1,
                                                    "pervious_surface_fraction": 1,
                                                    "height_of_roughness_elements": 1,
-                                                   "terrain_roughness_length": 1],
-                                          "hLevMin": 3,
-                                          "hLevMax": 15,
-                                          "hThresholdLev2": 10],
+                                                   "terrain_roughness_length": 1]]
                         ]
         ]
         IProcess process = OSM.workflow
@@ -452,6 +449,9 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "folder" : "$directory"],
                 "parameters":
                         ["distance" : 100,
+                         "hLevMin": 3,
+                         "hLevMax": 15,
+                         "hThresholdLev2": 10,
                          rsu_indicators: ["indicatorUse": ["LCZ"],
                                           "svfSimplified": true,
                          "mapOfWeights":
@@ -462,10 +462,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                                   "pervious_surface_fraction": 1,
                                   "height_of_roughness_elements": 1,
                                   "terrain_roughness_length": 1 ,
-                                  "terrain_roughness_class": 1 ],
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10]
+                                  "terrain_roughness_class": 1 ]]
                         ]
         ]
         IProcess process = OSM.workflow
@@ -559,6 +556,9 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "folder" : "$directory"],
                 "parameters":
                         ["distance" : 0,
+                         "hLevMin": 3,
+                         "hLevMax": 15,
+                         "hThresholdLev2": 10,
                          rsu_indicators:[
                          "svfSimplified": true,
                          "mapOfWeights":
@@ -568,10 +568,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                                   "impervious_surface_fraction" : 1,
                                   "pervious_surface_fraction": 1,
                                   "height_of_roughness_elements": 1,
-                                  "terrain_roughness_length": 1  ],
-                         "hLevMin": 3,
-                         "hLevMax": 15,
-                         "hThresholdLev2": 10]
+                                  "terrain_roughness_length": 1  ]]
                         ]
         ]
         IProcess process = OSM.workflow

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -566,9 +566,9 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                          "prefixName": "",
                          "estimateHeight":true,
                          "grid_indicators": [
-                             "x_size": 1000,
-                             "y_size": 1000,
-                             "indicators": ["RSU_LCZ"]
+                             "x_size": 100,
+                             "y_size": 100,
+                             "indicators": ["RSU_LCZ", "WATER_AREA"]
                          ]
                         ]
         ]

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -544,7 +544,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
     @Disabled
     @Test
     void testGrid_Indicators() {
-        String directory ="./target/geoclimate_chain_estimated_height"
+        String directory ="./target/geoclimate_chain_grid"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -561,7 +561,6 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         ["distance" : 0,
                          rsu_indicators:[
                          "svfSimplified": true,
-                         "prefixName": "",
                          "mapOfWeights":
                                  ["sky_view_factor": 1,
                                   "aspect_ratio": 1,

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -16,7 +16,6 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
     @Test
     void osmToRSU() {
         String directory ="./target/osm_processchain_geoindicators_rsu"
-
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()

--- a/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_envelope_folderoutput.json
+++ b/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_envelope_folderoutput.json
@@ -11,6 +11,9 @@
      "folder" : "/tmp/..."},
     "parameters":
     {"distance" : 1000,
+        "hLevMin": 3,
+        "hLevMax": 15,
+        "hThresholdLev2": 10,
         "rsu_indicators": {
         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
         "svfSimplified": false,
@@ -23,10 +26,7 @@
             "height_of_roughness_elements": 1,
             "terrain_roughness_class": 1,
             "lczRandomForest": false},
-        "hLevMin": 3,
-        "hLevMax": 15,
-        "hThresholdLev2": 10,
-        "estimateHeight" : false
+            "estimateHeight" : false
         }
     }
 }

--- a/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_envelope_folderoutput.json
+++ b/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_envelope_folderoutput.json
@@ -11,9 +11,9 @@
      "folder" : "/tmp/..."},
     "parameters":
     {"distance" : 1000,
+        "rsu_indicators": {
         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
         "svfSimplified": false,
-        "prefixName": "",
         "mapOfWeights":
         {"sky_view_factor": 1,
             "aspect_ratio": 1,
@@ -27,5 +27,6 @@
         "hLevMax": 15,
         "hThresholdLev2": 10,
         "estimateHeight" : false
+        }
     }
 }

--- a/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_mixedfilter_folderoutput.json
+++ b/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_mixedfilter_folderoutput.json
@@ -12,6 +12,9 @@
     "parameters":
     {"distance" : 1000,
         "prefixName": "",
+        "hLevMin": 3,
+        "hLevMax": 15,
+        "hThresholdLev2": 10,
         "rsu_indicators": {
         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
         "svfSimplified": false,
@@ -24,9 +27,6 @@
             "height_of_roughness_elements": 1,
             "terrain_roughness_class": 1,
             "lczRandomForest": false},
-        "hLevMin": 3,
-        "hLevMax": 15,
-        "hThresholdLev2": 10,
         "estimateHeight" : false
         }
     }

--- a/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_mixedfilter_folderoutput.json
+++ b/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_mixedfilter_folderoutput.json
@@ -11,9 +11,10 @@
      "folder" : "/tmp/..."},
     "parameters":
     {"distance" : 1000,
+        "prefixName": "",
+        "rsu_indicators": {
         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
         "svfSimplified": false,
-        "prefixName": "",
         "mapOfWeights":
         {"sky_view_factor": 1,
             "aspect_ratio": 1,
@@ -27,5 +28,6 @@
         "hLevMax": 15,
         "hThresholdLev2": 10,
         "estimateHeight" : false
+        }
     }
 }

--- a/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_placename_dboutput.json
+++ b/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_placename_dboutput.json
@@ -21,9 +21,9 @@
     },
     "parameters":
     {"distance" : 1000,
+        "rsu_indicators": {
         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
         "svfSimplified": false,
-        "prefixName": "",
         "mapOfWeights":
         {"sky_view_factor": 1,
             "aspect_ratio": 1,
@@ -37,5 +37,6 @@
         "hLevMax": 15,
         "hThresholdLev2": 10,
         "estimateHeight" : false
+        }
     }
 }

--- a/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_placename_dboutput.json
+++ b/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_placename_dboutput.json
@@ -21,6 +21,9 @@
     },
     "parameters":
     {"distance" : 1000,
+        "hLevMin": 3,
+        "hLevMax": 15,
+        "hThresholdLev2": 10,
         "rsu_indicators": {
         "indicatorUse": ["LCZ", "URBAN_TYPOLOGY", "TEB"],
         "svfSimplified": false,
@@ -33,9 +36,6 @@
             "height_of_roughness_elements": 1,
             "terrain_roughness_class": 1,
             "lczRandomForest": false},
-        "hLevMin": 3,
-        "hLevMax": 15,
-        "hThresholdLev2": 10,
         "estimateHeight" : false
         }
     }

--- a/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_placename_folderoutput.json
+++ b/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_placename_folderoutput.json
@@ -11,11 +11,15 @@
         "folder" : "/home/decide/Bureau/GeoclimateTests3"},
     "parameters":
     {"distance" : 1000,
-        "indicatorUse": ["LCZ"],
-        "svfSimplified": false,
-        "prefixName": "","hLevMin": 3,
-        "hLevMax": 15,
-        "hThresholdLev2": 10,
-        "estimateHeight" : true
+        "rsu_indicators": {
+            "indicatorUse": [
+                "LCZ"
+            ],
+            "svfSimplified": false,
+            "hLevMin": 3,
+            "hLevMax": 15,
+            "hThresholdLev2": 10,
+            "estimateHeight": true
+        }
     }
 }

--- a/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_placename_folderoutput.json
+++ b/osm/src/test/resources/org/orbisgis/orbisprocess/geoclimate/osm/config/osm_workflow_placename_folderoutput.json
@@ -11,14 +11,14 @@
         "folder" : "/home/decide/Bureau/GeoclimateTests3"},
     "parameters":
     {"distance" : 1000,
+        "hLevMin": 3,
+        "hLevMax": 15,
+        "hThresholdLev2": 10,
         "rsu_indicators": {
             "indicatorUse": [
                 "LCZ"
             ],
             "svfSimplified": false,
-            "hLevMin": 3,
-            "hLevMax": 15,
-            "hThresholdLev2": 10,
             "estimateHeight": true
         }
     }

--- a/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
+++ b/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
@@ -1418,6 +1418,7 @@ IProcess computeAllGeoIndicators() {
                 }
 
                 //Populate reporting
+
                 def nbBuilding = datasource.firstRow("select count(*) as count from ${computeBuildingsIndicators.getResults().outputTableName} WHERE ID_RSU IS NOT NULL").count
 
                 def nbBlock = 0

--- a/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
+++ b/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
@@ -1099,7 +1099,6 @@ IProcess computeAllGeoIndicators() {
                                                         ON a.id_build=b.id_build
                                                     WHERE b.ESTIMATED = true AND a.ID_RSU IS NOT NULL;"""
 
-
                 info "Collect building indicators to estimate the height"
 
                 def applygatherScales = Geoindicators.GenericIndicators.gatherScales()


### PR DESCRIPTION
This PR adds a new process to aggregate the indicators on a grid.
The user can set the x and y size of the grid and a list of indicators to compute.
The workflow configuration file has been modified to offer a way to compute the rsu indicators or/and the grid indicators.
Geoclimate can be used now to extract GIS layers and compute surface fractions  on a grid.

Example : 
```json
"parameters":
                        ["distance" : 0,
                         rsu_indicators:[
                         "svfSimplified": true,
                         "mapOfWeights":
                                 ["sky_view_factor": 1,
                                  "aspect_ratio": 1,
                                  "building_surface_fraction": 1,
                                  "impervious_surface_fraction" : 1,
                                  "pervious_surface_fraction": 1,
                                  "height_of_roughness_elements": 1,
                                  "terrain_roughness_length": 1  ],
                         "hLevMin": 3,
                         "hLevMax": 15,
                         "hThresholdLev2": 10],
                         "grid_indicators": [
                             "x_size": 100,
                             "y_size": 100,
                             "indicators": ["WATER_FRACTION"]
                         ]
```

About #https://github.com/orbisgis/geoclimate/issues/496

@ELSW56  @ernlt 