### PR TITLE
Ascii grid output and temporary tables deletion

### DIFF
--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/DataUtils.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/DataUtils.groovy
@@ -121,3 +121,26 @@ IProcess saveTablesAsFiles() {
         }
     }
 }
+
+/**
+ * An utility process to drop several tables. Usefull for example for dropping temporary tables.
+ *
+ * @param  inputTableNames list of the names of the tables to drop
+ * @param datasource connection to the database
+ *
+ * @return
+ */
+IProcess dropTables() {
+    return create {
+        title "Utility process to drop several tables"
+        id "dropTables"
+        inputs inputTableNames: List, datasource: JdbcDataSource
+        outputs dropped: Boolean
+        run { inputTableNames, datasource ->
+            inputTableNames.each { tableName ->
+                datasource "DROP TABLE IF EXISTS $tableName"
+            }
+            [dropped: true]
+        }
+    }
+}

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -15,40 +15,40 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
     @Test
     void osmToRSU() {
-        String directory ="./target/osm_processchain_geoindicators_rsu"
+        String directory = "./target/osm_processchain_geoindicators_rsu"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
-        def h2GIS = H2GIS.open(dirFile.absolutePath+File.separator+'osm_chain_db;AUTO_SERVER=TRUE')
+        def h2GIS = H2GIS.open(dirFile.absolutePath + File.separator + 'osm_chain_db;AUTO_SERVER=TRUE')
         def zoneToExtract = "Pont-de-Veyle"
         IProcess process = OSM.buildGeoclimateLayers
 
-        process.execute([datasource: h2GIS, zoneToExtract :zoneToExtract, distance: 0])
+        process.execute([datasource: h2GIS, zoneToExtract: zoneToExtract, distance: 0])
 
-        def prefixName  = zoneToExtract.trim().split("\\s*(,|\\s)\\s*").join("_");
+        def prefixName = zoneToExtract.trim().split("\\s*(,|\\s)\\s*").join("_");
 
         // Create the RSU
         def prepareRSUData = Geoindicators.SpatialUnits.prepareRSUData()
         def createRSU = Geoindicators.SpatialUnits.createRSU()
-        if (prepareRSUData([datasource        : h2GIS,
-                             zoneTable         : process.getResults().outputZone,
-                             roadTable         : process.getResults().outputRoad,
-                             railTable         : process.getResults().outputRail,
-                             vegetationTable   : process.getResults().outputVeget,
-                             hydrographicTable : process.getResults().outputHydro,
-                             prefixName        : prefixName])) {
+        if (prepareRSUData([datasource       : h2GIS,
+                            zoneTable        : process.getResults().outputZone,
+                            roadTable        : process.getResults().outputRoad,
+                            railTable        : process.getResults().outputRail,
+                            vegetationTable  : process.getResults().outputVeget,
+                            hydrographicTable: process.getResults().outputHydro,
+                            prefixName       : prefixName])) {
             def saveTables = Geoindicators.DataUtils.saveTablesAsFiles()
 
-            saveTables.execute( [inputTableNames: process.getResults().values(), delete:true
-                                 , directory: directory, datasource: h2GIS])
+            saveTables.execute([inputTableNames: process.getResults().values(), delete: true
+                                , directory    : directory, datasource: h2GIS])
 
-            if (createRSU([datasource    : h2GIS,
-                            inputTableName: prepareRSUData.results.outputTableName,
-                            inputZoneTableName :process.getResults().outputZone,
-                            prefixName    : prefixName])) {
+            if (createRSU([datasource        : h2GIS,
+                           inputTableName    : prepareRSUData.results.outputTableName,
+                           inputZoneTableName: process.getResults().outputZone,
+                           prefixName        : prefixName])) {
                 //TODO enable it for debug purpose
                 // h2GIS.getTable(createRSU.results.outputTableName).save(dirFile.absolutePath+File.separator+"${prefixName}.geojson", true)
-                assertTrue(h2GIS.getTable(createRSU.results.outputTableName).getRowCount()>0)
+                assertTrue(h2GIS.getTable(createRSU.results.outputTableName).getRowCount() > 0)
             }
         }
     }
@@ -56,7 +56,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
     @Test
     void osmGeoIndicatorsFromTestFiles() {
         String urlBuilding = new File(getClass().getResource("BUILDING.geojson").toURI()).absolutePath
-        String urlRoad= new File(getClass().getResource("ROAD.geojson").toURI()).absolutePath
+        String urlRoad = new File(getClass().getResource("ROAD.geojson").toURI()).absolutePath
         String urlRail = new File(getClass().getResource("RAIL.geojson").toURI()).absolutePath
         String urlVeget = new File(getClass().getResource("VEGET.geojson").toURI()).absolutePath
         String urlHydro = new File(getClass().getResource("HYDRO.geojson").toURI()).absolutePath
@@ -64,7 +64,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
         //TODO enable it for debug purpose
         boolean saveResults = false
-        String directory ="./target/osm_processchain_geoindicators_redon"
+        String directory = "./target/osm_processchain_geoindicators_redon"
         def prefixName = ""
         def indicatorUse = ["URBAN_TYPOLOGY", "LCZ", "TEB"]
         def svfSimplified = true
@@ -73,14 +73,14 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         dirFile.delete()
         dirFile.mkdir()
 
-        H2GIS datasource = H2GIS.open(dirFile.absolutePath+File.separator+"osm_chain_db;AUTO_SERVER=TRUE")
+        H2GIS datasource = H2GIS.open(dirFile.absolutePath + File.separator + "osm_chain_db;AUTO_SERVER=TRUE")
 
-        String zoneTableName="zone"
-        String buildingTableName="building"
-        String roadTableName="road"
-        String railTableName="rails"
-        String vegetationTableName="veget"
-        String hydrographicTableName="hydro"
+        String zoneTableName = "zone"
+        String buildingTableName = "building"
+        String roadTableName = "road"
+        String railTableName = "rails"
+        String vegetationTableName = "veget"
+        String hydrographicTableName = "hydro"
 
 
         datasource.load(urlBuilding, buildingTableName, true)
@@ -91,14 +91,14 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         datasource.load(urlZone, zoneTableName, true)
 
         //Run tests
-        geoIndicatorsCalc(dirFile.absolutePath+File, datasource, zoneTableName, buildingTableName,roadTableName,
-                null,vegetationTableName, hydrographicTableName,saveResults, svfSimplified, indicatorUse, prefixName)
+        geoIndicatorsCalc(dirFile.absolutePath + File, datasource, zoneTableName, buildingTableName, roadTableName,
+                null, vegetationTableName, hydrographicTableName, saveResults, svfSimplified, indicatorUse, prefixName)
 
     }
 
     @Test
     void osmGeoIndicatorsFromApi() {
-        String directory ="./target/osm_processchain_indicators"
+        String directory = "./target/osm_processchain_indicators"
         //TODO enable it for debug purpose
         boolean saveResults = false
         def prefixName = ""
@@ -107,14 +107,14 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         dirFile.delete()
         dirFile.mkdir()
 
-        H2GIS datasource = H2GIS.open(dirFile.absolutePath+File.separator+"osm_chain_db;AUTO_SERVER=TRUE")
+        H2GIS datasource = H2GIS.open(dirFile.absolutePath + File.separator + "osm_chain_db;AUTO_SERVER=TRUE")
 
         //Extract and transform OSM data
         def zoneToExtract = "Pont-de-Veyle"
 
         IProcess prepareOSMData = OSM.buildGeoclimateLayers
 
-        prepareOSMData.execute([datasource: datasource, zoneToExtract :zoneToExtract, distance: 0])
+        prepareOSMData.execute([datasource: datasource, zoneToExtract: zoneToExtract, distance: 0])
 
         String buildingTableName = prepareOSMData.getResults().outputBuilding
 
@@ -128,19 +128,19 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
         String zoneTableName = prepareOSMData.getResults().outputZone
 
-        if(saveResults){
+        if (saveResults) {
             println("Saving OSM GIS layers")
             IProcess saveTables = ProcessingChain.DataUtils.saveTablesAsFiles
-            saveTables.execute( [inputTableNames: [buildingTableName,roadTableName,railTableName,hydrographicTableName,
-                                                   vegetationTableName,zoneTableName]
-                                 , directory: dirFile.absolutePath, datasource: datasource])
+            saveTables.execute([inputTableNames: [buildingTableName, roadTableName, railTableName, hydrographicTableName,
+                                                  vegetationTableName, zoneTableName]
+                                , directory    : dirFile.absolutePath, datasource: datasource])
         }
 
         def indicatorUse = ["TEB", "URBAN_TYPOLOGY", "LCZ"]
 
         //Run tests
-        geoIndicatorsCalc(dirFile.absolutePath, datasource, zoneTableName, buildingTableName,roadTableName,railTableName,vegetationTableName,
-                hydrographicTableName,saveResults, svfSimplified,indicatorUse,  prefixName)
+        geoIndicatorsCalc(dirFile.absolutePath, datasource, zoneTableName, buildingTableName, roadTableName, railTableName, vegetationTableName,
+                hydrographicTableName, saveResults, svfSimplified, indicatorUse, prefixName)
 
     }
 
@@ -149,7 +149,7 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
     @Test
     void osmLczFromTestFiles() {
         String urlBuilding = new File(getClass().getResource("BUILDING.geojson").toURI()).absolutePath
-        String urlRoad= new File(getClass().getResource("ROAD.geojson").toURI()).absolutePath
+        String urlRoad = new File(getClass().getResource("ROAD.geojson").toURI()).absolutePath
         String urlRail = new File(getClass().getResource("RAIL.geojson").toURI()).absolutePath
         String urlVeget = new File(getClass().getResource("VEGET.geojson").toURI()).absolutePath
         String urlHydro = new File(getClass().getResource("HYDRO.geojson").toURI()).absolutePath
@@ -157,20 +157,20 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
         //TODO enable it for debug purpose
         boolean saveResults = false
-        String directory ="./target/osm_processchain_lcz"
+        String directory = "./target/osm_processchain_lcz"
 
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
 
-        H2GIS datasource = H2GIS.open(dirFile.absolutePath+File.separator+"osmchain_lcz;AUTO_SERVER=TRUE")
+        H2GIS datasource = H2GIS.open(dirFile.absolutePath + File.separator + "osmchain_lcz;AUTO_SERVER=TRUE")
 
-        String zoneTableName="zone"
-        String buildingTableName="building"
-        String roadTableName="road"
-        String railTableName="rails"
-        String vegetationTableName="veget"
-        String hydrographicTableName="hydro"
+        String zoneTableName = "zone"
+        String buildingTableName = "building"
+        String roadTableName = "road"
+        String railTableName = "rails"
+        String vegetationTableName = "veget"
+        String hydrographicTableName = "hydro"
 
         datasource.load(urlBuilding, buildingTableName, true)
         datasource.load(urlRoad, roadTableName, true)
@@ -188,142 +188,142 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                 buildingTable: buildingTableName, roadTable: roadTableName,
                 railTable: railTableName, vegetationTable: vegetationTableName,
                 hydrographicTable: hydrographicTableName, indicatorUse: ["LCZ"],
-                mapOfWeights: mapOfWeights,svfSimplified: true )
-        assertTrue(datasource.getTable(geodindicators.results.outputTableBuildingIndicators).rowCount>0)
+                mapOfWeights: mapOfWeights, svfSimplified: true)
+        assertTrue(datasource.getTable(geodindicators.results.outputTableBuildingIndicators).rowCount > 0)
         assertNotNull(geodindicators.results.outputTableBlockIndicators)
-        assertTrue(datasource.getTable(geodindicators.results.outputTableRsuIndicators).rowCount>0)
-        assertTrue(datasource.getTable(geodindicators.results.outputTableRsuLcz).rowCount>0)
+        assertTrue(datasource.getTable(geodindicators.results.outputTableRsuIndicators).rowCount > 0)
+        assertTrue(datasource.getTable(geodindicators.results.outputTableRsuLcz).rowCount > 0)
     }
 
     @Test
     void osmWorkflowToH2Database() {
-        String directory ="./target/geoclimate_chain_db"
+        String directory = "./target/geoclimate_chain_db"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the result into a database",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :false
+                "description" : "Example of configuration file to run the OSM workflow and store the result into a database",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": false
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                        "database" :
-                                ["user" : "sa",
-                                "password":"",
-                                 "url": "jdbc:h2://${dirFile.absolutePath+File.separator+"geoclimate_chain_db_output;AUTO_SERVER=TRUE"}",
-                                 "tables": [
-                                          "rsu_indicators":"rsu_indicators",
-                                          "rsu_lcz":"rsu_lcz" ]]],
-                "parameters":
-                        ["distance" : 0,
-                         rsu_indicators: ["indicatorUse": ["LCZ"],
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "database":
+                                ["user"    : "sa",
+                                 "password": "",
+                                 "url"     : "jdbc:h2://${dirFile.absolutePath + File.separator + "geoclimate_chain_db_output;AUTO_SERVER=TRUE"}",
+                                 "tables"  : [
+                                         "rsu_indicators": "rsu_indicators",
+                                         "rsu_lcz"       : "rsu_lcz"]]],
+                "parameters"  :
+                        ["distance"    : 0,
+                         rsu_indicators: ["indicatorUse" : ["LCZ"],
                                           "svfSimplified": true,
-                                          "mapOfWeights":
-                                                  ["sky_view_factor": 1,
-                                                   "aspect_ratio": 1,
-                                                   "building_surface_fraction": 1,
+                                          "mapOfWeights" :
+                                                  ["sky_view_factor"             : 1,
+                                                   "aspect_ratio"                : 1,
+                                                   "building_surface_fraction"   : 1,
                                                    "impervious_surface_fraction" : 1,
-                                                   "pervious_surface_fraction": 1,
+                                                   "pervious_surface_fraction"   : 1,
                                                    "height_of_roughness_elements": 1,
-                                                   "terrain_roughness_length": 1]]
+                                                   "terrain_roughness_length"    : 1]]
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
-        H2GIS outputdb = H2GIS.open(dirFile.absolutePath+File.separator+"geoclimate_chain_db_output;AUTO_SERVER=TRUE")
+        H2GIS outputdb = H2GIS.open(dirFile.absolutePath + File.separator + "geoclimate_chain_db_output;AUTO_SERVER=TRUE")
         def rsu_indicatorsTable = outputdb.getTable("rsu_indicators")
         assertNotNull(rsu_indicatorsTable)
-        assertTrue(rsu_indicatorsTable.getRowCount()>0)
+        assertTrue(rsu_indicatorsTable.getRowCount() > 0)
         def rsu_lczTable = outputdb.getTable("rsu_lcz")
         assertNotNull(rsu_lczTable)
-        assertTrue(rsu_lczTable.getRowCount()>0)
+        assertTrue(rsu_lczTable.getRowCount() > 0)
     }
 
     @Test
     void osmWorkflowToPostGISDatabase() {
-        String directory ="./target/geoclimate_chain_postgis"
+        String directory = "./target/geoclimate_chain_postgis"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                "description" : "Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": true
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                        "database" :
-                                ["user" : "orbisgis",
-                                 "password":"orbisgis",
-                                 "url": "jdbc:postgresql://localhost:5432/orbisgis_db",
-                                 "tables": [
-                                            "rsu_indicators":"rsu_indicators",
-                                            "rsu_lcz":"rsu_lcz",
-                                            "zones":"zones" ,
-                                            "grid_indicators":"grid_indicators"]]],
-                "parameters":
-                        ["distance" : 0,
-                         rsu_indicators: ["indicatorUse": ["LCZ"],
-                                          "svfSimplified": true] ,
-                        "grid_indicators": [
-                        "x_size": 1000,
-                        "y_size": 1000,
-                        "indicators": ["ROAD_FRACTION"]
-                        ]
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "database":
+                                ["user"    : "orbisgis",
+                                 "password": "orbisgis",
+                                 "url"     : "jdbc:postgresql://localhost:5432/orbisgis_db",
+                                 "tables"  : [
+                                         "rsu_indicators" : "rsu_indicators",
+                                         "rsu_lcz"        : "rsu_lcz",
+                                         "zones"          : "zones",
+                                         "grid_indicators": "grid_indicators"]]],
+                "parameters"  :
+                        ["distance"       : 0,
+                         rsu_indicators   : ["indicatorUse" : ["LCZ"],
+                                             "svfSimplified": true],
+                         "grid_indicators": [
+                                 "x_size"    : 1000,
+                                 "y_size"    : 1000,
+                                 "indicators": ["ROAD_FRACTION"]
+                         ]
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
         def postgis_dbProperties = [databaseName: 'orbisgis_db',
-                                           user        : 'orbisgis',
-                                           password    : 'orbisgis',
-                                           url         : 'jdbc:postgresql://localhost:5432/'
+                                    user        : 'orbisgis',
+                                    password    : 'orbisgis',
+                                    url         : 'jdbc:postgresql://localhost:5432/'
         ]
         POSTGIS postgis = POSTGIS.open(postgis_dbProperties);
-        if(postgis){
+        if (postgis) {
             def rsu_indicatorsTable = postgis.getTable("rsu_indicators")
             assertNotNull(rsu_indicatorsTable)
-            assertTrue(rsu_indicatorsTable.getRowCount()>0)
+            assertTrue(rsu_indicatorsTable.getRowCount() > 0)
             def rsu_lczTable = postgis.getTable("rsu_lcz")
             assertNotNull(rsu_lczTable)
-            assertTrue(rsu_lczTable.getRowCount()>0)
+            assertTrue(rsu_lczTable.getRowCount() > 0)
             def zonesTable = postgis.getTable("zones")
             assertNotNull(zonesTable)
-            assertTrue(zonesTable.getRowCount()>0)
+            assertTrue(zonesTable.getRowCount() > 0)
             def gridTable = postgis.getTable("grid_indicators")
             assertNotNull(gridTable)
-            assertTrue(gridTable.getRowCount()>0)
+            assertTrue(gridTable.getRowCount() > 0)
         }
     }
 
     @Test
     void testOSMWorkflowFromPlaceNameWithSrid() {
-        String directory ="./target/geoclimate_chain_srid"
+        String directory = "./target/geoclimate_chain_srid"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the results in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :false
+                "description" : "Example of configuration file to run the OSM workflow and store the results in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": false
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                        "folder" : "${directory}",
-                        "srid":"4326"],
-                "parameters":
-                        ["distance" : 0,
-                         rsu_indicators: ["indicatorUse": ["LCZ"],
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "folder": "${directory}",
+                        "srid"  : "4326"],
+                "parameters"  :
+                        ["distance"    : 0,
+                         rsu_indicators: ["indicatorUse" : ["LCZ"],
                                           "svfSimplified": true]
                         ]
         ]
@@ -331,14 +331,14 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
         //Test the SRID of all output files
         def geoFiles = []
-        def  folder = new File("${directory+File.separator}osm_Pont-de-Veyle")
-        folder.eachFileRecurse groovy.io.FileType.FILES,  { file ->
+        def folder = new File("${directory + File.separator}osm_Pont-de-Veyle")
+        folder.eachFileRecurse groovy.io.FileType.FILES, { file ->
             if (file.name.toLowerCase().endsWith(".geojson")) {
                 geoFiles << file.getAbsolutePath()
             }
         }
-        H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
-        geoFiles.eachWithIndex { geoFile , index->
+        H2GIS h2gis = H2GIS.open("${directory + File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
+        geoFiles.eachWithIndex { geoFile, index ->
             def tableName = h2gis.load(geoFile, true)
             assertEquals(4326, h2gis.getSpatialTable(tableName).srid)
         }
@@ -346,23 +346,23 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
     @Test
     void testOSMWorkflowFromPlaceName() {
-        String directory ="./target/geoclimate_chain"
+        String directory = "./target/geoclimate_chain"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                "description" : "Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": true
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                        "folder" : "$directory"],
-                "parameters":
-                        [rsu_indicators: ["indicatorUse": ["LCZ"],
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "folder": "$directory"],
+                "parameters"  :
+                        [rsu_indicators: ["indicatorUse" : ["LCZ"],
                                           "svfSimplified": true]
                         ]
         ]
@@ -374,21 +374,21 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
     @Disabled
     @Test
     void testOSMWorkflowFromBboxDeleteDBFalse() {
-        String directory ="./target/geoclimate_chain"
+        String directory = "./target/geoclimate_chain"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                "description" : "Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": true
                 ],
-                "input" : [
-                        "osm" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
-                "output" :[
-                        "folder" : "$directory"]
+                "input"       : [
+                        "osm": [[38.89557963573336, -77.03930318355559, 38.89944983078282, -77.03364372253417]]],
+                "output"      : [
+                        "folder": "$directory"]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
@@ -396,21 +396,21 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
     @Test
     void testOSMWorkflowFromBbox() {
-        String directory ="./target/geoclimate_chain"
+        String directory = "./target/geoclimate_chain"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                "description" : "Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": true
                 ],
-                "input" : [
-                        "osm" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
-                "output" :[
-                        "folder" : "$directory"]
+                "input"       : [
+                        "osm": [[38.89557963573336, -77.03930318355559, 38.89944983078282, -77.03364372253417]]],
+                "output"      : [
+                        "folder": "$directory"]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
@@ -418,21 +418,21 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
     @Test
     void testOSMWorkflowBadOSMFilters() {
-        String directory ="./target/geoclimate_chain"
+        String directory = "./target/geoclimate_chain"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                "description" : "Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": true
                 ],
-                "input" : [
-                        "osm" : ["", [-3.0961382389068604, -3.1055688858032227,48.77155634881654,]]],
-                "output" :[
-                        "folder" : "$directory"]
+                "input"       : [
+                        "osm": ["", [-3.0961382389068604, -3.1055688858032227, 48.77155634881654,]]],
+                "output"      : [
+                        "folder": "$directory"]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
@@ -440,37 +440,37 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
     @Test
     void workflowWrongMapOfWeights() {
-        String directory ="./target/bdtopo_workflow"
+        String directory = "./target/bdtopo_workflow"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                "description" : "Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": true
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                        "folder" : "$directory"],
-                "parameters":
-                        ["distance" : 100,
-                         "hLevMin": 3,
-                         "hLevMax": 15,
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "folder": "$directory"],
+                "parameters"  :
+                        ["distance"      : 100,
+                         "hLevMin"       : 3,
+                         "hLevMax"       : 15,
                          "hThresholdLev2": 10,
-                         rsu_indicators: ["indicatorUse": ["LCZ"],
-                                          "svfSimplified": true,
-                         "mapOfWeights":
-                                 ["sky_view_factor": 1,
-                                  "aspect_ratio": 1,
-                                  "building_surface_fraction": 1,
-                                  "impervious_surface_fraction" : 1,
-                                  "pervious_surface_fraction": 1,
-                                  "height_of_roughness_elements": 1,
-                                  "terrain_roughness_length": 1 ,
-                                  "terrain_roughness_class": 1 ]]
+                         rsu_indicators  : ["indicatorUse" : ["LCZ"],
+                                            "svfSimplified": true,
+                                            "mapOfWeights" :
+                                                    ["sky_view_factor"             : 1,
+                                                     "aspect_ratio"                : 1,
+                                                     "building_surface_fraction"   : 1,
+                                                     "impervious_surface_fraction" : 1,
+                                                     "pervious_surface_fraction"   : 1,
+                                                     "height_of_roughness_elements": 1,
+                                                     "terrain_roughness_length"    : 1,
+                                                     "terrain_roughness_class"     : 1]]
                         ]
         ]
         IProcess process = OSM.workflow
@@ -480,26 +480,26 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
     @Disabled
     @Test
     void testOSMEstimatedHeight() {
-        String directory ="./target/geoclimate_chain_estimated_height"
+        String directory = "./target/geoclimate_chain_estimated_height"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the results in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                "description" : "Example of configuration file to run the OSM workflow and store the results in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": true
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                        "folder" : "$directory"],
-                "parameters":
-                        ["distance" : 0,
-                         rsu_indicators: ["indicatorUse": ["LCZ", "URBAN_TYPOLOGY"],
-                         "svfSimplified": true,
-                         "estimateHeight":true]
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "folder": "$directory"],
+                "parameters"  :
+                        ["distance"    : 0,
+                         rsu_indicators: ["indicatorUse"  : ["LCZ", "URBAN_TYPOLOGY"],
+                                          "svfSimplified" : true,
+                                          "estimateHeight": true]
                         ]
         ]
         IProcess process = OSM.workflow
@@ -508,96 +508,97 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
     @Test
     void testOnlyEstimateHeight() {
-        String directory ="./target/geoclimate_chain_grid"
+        String directory = "./target/geoclimate_chain_grid"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run only the estimated height model",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :false
+                "description" : "Example of configuration file to run only the estimated height model",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": false
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                        "folder" : ["path": "$directory",
-                                    "tables": ["building"]]],
-                "parameters":
-                        ["distance" : 0,
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "folder": ["path"  : "$directory",
+                                   "tables": ["building"]]],
+                "parameters"  :
+                        ["distance"      : 0,
                          "rsu_indicators": [
-                                 "svfSimplified": true,
-                                 "estimateHeight":true
+                                 "svfSimplified" : true,
+                                 "estimateHeight": true
                          ]
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
-        H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
-        assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count>0
+        H2GIS h2gis = H2GIS.open("${directory + File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
+        assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count > 0
     }
 
 
     @Test
     void testGrid_Indicators() {
-        String directory ="./target/geoclimate_chain_grid"
+        String directory = "./target/geoclimate_chain_grid"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the grid indicators",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :false
+                "description" : "Example of configuration file to run the grid indicators",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": false
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                "folder" : ["path": "$directory",
-                    "tables": ["grid_indicators"]]],
-                "parameters":
-                        ["distance" : 0,
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "folder": ["path"  : "$directory",
+                                   "tables": ["zones","rsu_indicators", "rsu_lcz","grid_indicators"]]],
+                "parameters"  :
+                        ["distance"       : 0,
                          "grid_indicators": [
-                             "x_size": 1000,
-                             "y_size": 1000,
-                             "indicators": ["WATER_FRACTION"]
+                                 "x_size"    : 1000,
+                                 "y_size"    : 1000,
+                                 "indicators": ["WATER_FRACTION"]
                          ]
                         ]
         ]
         IProcess process = OSM.workflow
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
-        H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
-        assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count>0
+        H2GIS h2gis = H2GIS.open("${directory + File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
+        assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count > 0
     }
 
-    @Disabled //Use it for debug
+    @Disabled
+    //Use it for debug
     @Test
     void testIntegration() {
-        String directory ="./target/geoclimate_chain_integration"
+        String directory = "./target/geoclimate_chain_integration"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :false
+                "description" : "Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": false
                 ],
-                "input" : [
-                        "osm" : ["Nantes"]],
-                "output" :[
-                        "folder" :[ path : "$directory"], "tables": [
-                        "building_indicators":"building_indicators"
+                "input"       : [
+                        "osm": ["Nantes"]],
+                "output"      : [
+                        "folder": [path: "$directory"], "tables": [
+                        "building_indicators": "building_indicators"
                 ]],
-                "parameters":
-                        ["distance" : 0,
-                         "rsu_indicators":[
-                                 "indicatorUse": ["LCZ", "URBAN_TYPOLOGY"],
-                                 "svfSimplified": true,
-                                 "estimateHeight":true
+                "parameters"  :
+                        ["distance"      : 0,
+                         "rsu_indicators": [
+                                 "indicatorUse"  : ["LCZ", "URBAN_TYPOLOGY"],
+                                 "svfSimplified" : true,
+                                 "estimateHeight": true
                          ]
                         ]
         ]
@@ -608,25 +609,25 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
     @Test
     void testOSMTEB() {
-        String directory ="./target/geoclimate_chain"
+        String directory = "./target/geoclimate_chain"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the result in a folder",
-                "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete" :true
+                "description" : "Example of configuration file to run the OSM workflow and store the result in a folder",
+                "geoclimatedb": [
+                        "folder": "${dirFile.absolutePath}",
+                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete": true
                 ],
-                "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
-                "output" :[
-                        "folder" : "$directory"],
-                "parameters":
+                "input"       : [
+                        "osm": ["Pont-de-Veyle"]],
+                "output"      : [
+                        "folder": "$directory"],
+                "parameters"  :
                         [
-                                rsu_indicators:[
-                                        "indicatorUse": ["TEB"],
+                                rsu_indicators: [
+                                        "indicatorUse" : ["TEB"],
                                         "svfSimplified": true
                                 ]
                         ]
@@ -641,18 +642,19 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
      * @param directory
      * @return
      */
-    def createOSMConfigFile(def osmParameters, def directory){
+    def createOSMConfigFile(def osmParameters, def directory) {
         def json = JsonOutput.toJson(osmParameters)
-        def configFilePath =  directory+File.separator+"osmConfigFile.json"
+        def configFilePath = directory + File.separator + "osmConfigFile.json"
         File configFile = new File(configFilePath)
-        if(configFile.exists()){
+        if (configFile.exists()) {
             configFile.delete()
         }
         configFile.write(json)
         return configFile.absolutePath
     }
 
-    @Test //Integration tests
+    @Test
+    //Integration tests
     @Disabled
     void testOSMConfigurationFile() {
         def configFile = getClass().getResource("config/osm_workflow_placename_folderoutput.json").toURI()
@@ -661,7 +663,8 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         assertTrue(process.execute(configurationFile: configFile))
     }
 
-    @Disabled //Enable this test to test some specific indicators
+    @Disabled
+    //Enable this test to test some specific indicators
     @Test
     void testIndicators() {
         boolean saveResults = true
@@ -689,11 +692,11 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
         String zoneTableName = prepareOSMData.getResults().outputZone
 
-        def  prepareData = Geoindicators.SpatialUnits.prepareRSUData()
-        assertTrue prepareData.execute([zoneTable: zoneTableName, roadTable: roadTableName,  railTable: '',
-                                        vegetationTable : vegetationTableName,
-                                        hydrographicTable :hydrographicTableName,
-                                        prefixName: "prepare_rsu", datasource: datasource])
+        def prepareData = Geoindicators.SpatialUnits.prepareRSUData()
+        assertTrue prepareData.execute([zoneTable        : zoneTableName, roadTable: roadTableName, railTable: '',
+                                        vegetationTable  : vegetationTableName,
+                                        hydrographicTable: hydrographicTableName,
+                                        prefixName       : "prepare_rsu", datasource: datasource])
 
         def outputTableGeoms = prepareData.results.outputTableName
 
@@ -702,11 +705,11 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         def rsu = Geoindicators.SpatialUnits.createRSU()
         assertTrue rsu.execute([inputTableName: outputTableGeoms, prefixName: "rsu", datasource: datasource])
         def outputTable = rsu.results.outputTableName
-        assertTrue datasource.save(outputTable,'./target/rsu.shp', true)
+        assertTrue datasource.save(outputTable, './target/rsu.shp', true)
 
-        def  p =  Geoindicators.RsuIndicators.smallestCommunGeometry()
+        def p = Geoindicators.RsuIndicators.smallestCommunGeometry()
         assertTrue p.execute([
-                rsuTable: outputTable,buildingTable: buildingTableName, roadTable:roadTableName,vegetationTable: vegetationTableName,waterTable: hydrographicTableName,
+                rsuTable  : outputTable, buildingTable: buildingTableName, roadTable: roadTableName, vegetationTable: vegetationTableName, waterTable: hydrographicTableName,
                 prefixName: "test", datasource: datasource])
         def outputTableStats = p.results.outputTableName
 
@@ -722,5 +725,45 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
 
         datasource.save("stats_rsu", './target/stats_rsu.shp', true)
 
+    }
+
+    @Test
+    void TestAsciiGrid() {
+
+        H2GIS h2gis_datasource = H2GIS.open("D:/Users/le_sauxe/Documents/IUT/Recherche/Labsticc/SLIM/geoclimate_chain/slim_1610967941742;AUTO_SERVER=TRUE")
+        def output_files_generic_name = "D:/Users/le_sauxe/Documents/IUT/Recherche/Labsticc/SLIM/geoclimate_chain/"
+        def h2gis_table_to_save = "GRID_INDICATORS"
+        def query = "select max(id_col) as cmax, max(id_row) as rmax from GRID_INDICATORS"
+        def nbcols
+        def nbrows
+        h2gis_datasource.eachRow(query){row ->
+            nbcols = row.cmax
+            nbrows = row.rmax
+        }
+        def env = h2gis_datasource.getSpatialTable(h2gis_table_to_save).getExtent().getEnvelopeInternal();
+        def xmin =env.getMinX()
+        def ymin =env.getMinY()
+
+        def IndicsTable = h2gis_datasource."$h2gis_table_to_save"
+        List columnNames = IndicsTable.columns
+        columnNames.remove("THE_GEOM")
+        columnNames.remove("ID")
+        columnNames.remove("ID_COL")
+        columnNames.remove("ID_ROW")
+        columnNames.each { it ->
+            new File("${output_files_generic_name}${it}.asc").withOutputStream { stream ->
+                stream.write "ncols $nbcols\nnrows $nbrows\nxllcorner $xmin\nyllcorner $ymin\ncellsize ???\nnodata_value -9999\n".getBytes()
+                query = "select id_row, id_col, $it from $h2gis_table_to_save order by id_row, id_col"
+                String fileContent = ""
+                h2gis_datasource.eachRow(query) { row ->
+                    fileContent += row.getString(it) + " "
+                    if (row.getInt("id_col") == nbcols) {
+                        fileContent += "\n"
+                        stream.write fileContent.getBytes()
+                        fileContent=""
+                    }
+                }
+            }
+        }
     }
 }

--- a/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
+++ b/processingchain/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChain.groovy
@@ -2029,6 +2029,10 @@ IProcess rasterizeIndicators() {
                     info "Cannot merge all indicators in grid table $grid_indicators_table."
                     return
                 }
+                def dropTempTables = Geoindicators.DataUtils.dropTables()
+                def tablesToDrop = indicatorTablesToJoin.keySet().toList()
+                dropTempTables([inputTableNames: tablesToDrop,
+                                   datasource           : datasource])
             }
             [outputTableName: grid_indicators_table]
         }

--- a/processingchain/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChainTest.groovy
+++ b/processingchain/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/processingchain/GeoIndicatorsChainTest.groovy
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.orbisgis.orbisdata.datamanager.dataframe.DataFrame
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 import org.orbisgis.orbisdata.processmanager.api.IProcess
+import org.orbisgis.orbisprocess.geoclimate.geoindicators.Geoindicators
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -434,6 +435,19 @@ class GeoIndicatorsChainTest {
         } else {
             assertEquals(null, GeoIndicatorsCompute_i.results.outputTableRsuLcz)
         }
+    }
+
+    @Test
+    void GeoIndicatorsTest8() {
+        File directory = new File("./target/geoindicators_workflow")
+        def dir = directory.absolutePath
+        H2GIS datasource = H2GIS.open("D:/Users/le_sauxe/Documents/IUT/Recherche/Test_Geoclimate"
+                + File.separator + "geoclimate_db;AUTO_SERVER=TRUE")
+        def gridProcess = Geoindicators.SpatialUnits.createGrid()
+        def box = datasource.getSpatialTable("emprise").getExtent()
+        gridProcess.execute([geometry: box, deltaX: 1000, deltaY: 1000,  datasource: datasource])
+        def grid_table_name = gridProcess.results.outputTableName
+        H2GIS.getTable(grid_table_name).save("./target/grid_table_name.shp", true)
     }
 
     /**


### PR DESCRIPTION
WorkflowOSM.groovy : Adding of a function to save the results as ascii grid files.

DataUtils.groovy : Adding of a function to drop the intermediate tables (applied only to grid_indicators in GeoIndicatorsChain.groovy up to now)

The changes in the ProcessingChainOSMTests.groovy file are just due to indentation differences ...