### PR TITLE
Add option on osm workflow to delete xml files

### DIFF
--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -554,7 +554,8 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "osm" : ["Pont-de-Veyle"],
+                        "delete":true],
                 "output" :[
                 "folder" : ["path": "$directory",
                     "tables": ["grid_indicators", "zones"]]],


### PR DESCRIPTION
The option must be set in the config file. See the delete parameter in osm array.

```
[
                "description" :"Example of configuration file to run the grid indicators",
                "geoclimatedb" : [
                        "folder" : "${dirFile.absolutePath}",
                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                        "delete" :false
                ],
                "input" : [
                        "osm" : ["Pont-de-Veyle"],
                        "delete":true],
                "output" :[
                "folder" : ["path": "$directory",
                    "tables": ["grid_indicators", "zones"]]],
                "parameters":
                        ["distance" : 0,
                         "grid_indicators": [
                             "x_size": 1000,
                             "y_size": 1000,
                             "indicators": ["WATER_FRACTION"],
                             "output":"asc"
                         ]
                        ]
        ]
```