### PR TITLE
Change the upper scale process to return a fraction

### DIFF
--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/GenericIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/GenericIndicators.groovy
@@ -985,6 +985,7 @@ IProcess gatherScales() {
 /**
  * This process is used to compute aggregate the area of a specific variable to a upper scale from a lower scale (for
  * example the LCZs variables within a Reference Spatial Unit)
+ * The aggregate value is divided by the geometry area of the upper table
  *
  * @param upperTableName the name of the upper scale table
  * @param upperColumnId unique identifier for the upper scale table
@@ -1110,7 +1111,7 @@ IProcess upperScaleAreaStatistics() {
             listValues.each {
                 def aliasColumn = "${lowerColumnName}_${it.val.toString().replace('.','_')}"
                 qjoin += """
-                         , NVL($aliasColumn, 0)
+                         , NVL($aliasColumn, 0) / ST_AREA(b.$upperGeometryColumn)
                          AS $aliasColumn
                          """
             }

--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/RsuIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/RsuIndicators.groovy
@@ -1321,7 +1321,8 @@ return create {
                """
 
             //Polygonize the input tables
-            debug "Generating minimum polygon areas"
+            debug "Generating " +
+                    "minimum polygon areas"
             def tmp_point_polygonize = postfix "tmp_point_polygonize_zindex0"
             datasource """DROP TABLE IF EXISTS $tmp_point_polygonize;
                 CREATE TABLE $tmp_point_polygonize as  select  EXPLOD_ID as ${ID_COLUMN_NAME}, st_pointonsurface(st_force2D(the_geom)) as the_geom ,

--- a/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/GenericIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/GenericIndicatorsTests.groovy
@@ -586,10 +586,10 @@ class GenericIndicatorsTests {
         assertEquals(2, values.NB)
 
         values= h2GIS.firstRow "select sum_indic as nb from babeth_zone where id=3"
-        assertEquals(110000, values.NB)
+        assertEquals(0.11, values.NB)
 
         values= h2GIS.firstRow "select sum_indic as nb from babeth_zone where id=0"
-        assertEquals(7575, values.NB)
+        assertEquals(0.007575, values.NB)
 
     }
 }


### PR DESCRIPTION
Now when LCZ and Urban Typo variables are aggregated on a upper scale geometry, e.g a grid we return the fraction and not  the sum area