### PR TITLE
Add traffic flow estimation based on default values and road types

### DIFF
--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModel.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModel.groovy
@@ -1129,7 +1129,7 @@ IProcess mergeWaterAndSeaLandTables() {
             outputs outputTableName: String
             run { datasource, inputTableName, inputZoneEnvelopeTableName, epsg, jsonFilename ->
                 debug('Create the default traffic data')
-                def outputTableName = postfix "TRAFFIC_FLOW"
+                def outputTableName =  "TRAFFIC_FLOW"
                 datasource """
                 DROP TABLE IF EXISTS $outputTableName;
                 CREATE TABLE $outputTableName (THE_GEOM GEOMETRY(GEOMETRY, $epsg), ID_ROAD SERIAL, ID_SOURCE VARCHAR, 

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModel.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModel.groovy
@@ -8,6 +8,8 @@ import org.orbisgis.orbisdata.datamanager.api.dataset.ISpatialTable
 import org.orbisgis.orbisdata.datamanager.jdbc.JdbcDataSource
 import org.orbisgis.orbisdata.processmanager.api.IProcess
 
+import java.util.regex.Pattern
+
 @BaseScript OSM_Utils osm_utils
 
 /**
@@ -526,7 +528,7 @@ IProcess formatImperviousLayer() {
             datasource.execute """Drop table if exists $outputTableName;
                     CREATE TABLE $outputTableName (THE_GEOM GEOMETRY(POLYGON, $epsg), id_impervious serial, ID_SOURCE VARCHAR);"""
             debug(inputTableName)
-            if (inputTableName != null) {
+            if (inputTableName) {
                 def paramsDefaultFile = this.class.getResourceAsStream("imperviousParams.json")
                 def parametersMap = parametersMapping(jsonFilename, paramsDefaultFile)
                 def queryMapper = "SELECT "
@@ -1059,40 +1061,333 @@ IProcess mergeWaterAndSeaLandTables() {
     return create {
         title "Extract the sea/land mask"
         id "formatSeaLandMask"
-        inputs datasource: JdbcDataSource, inputSeaLandTableName: String,inputWaterTableName: String, epsg: int
+        inputs datasource: JdbcDataSource, inputSeaLandTableName: String, inputWaterTableName: String, epsg: int
         outputs outputTableName: String
-        run { JdbcDataSource datasource, inputSeaLandTableName,inputWaterTableName, epsg ->
+        run { JdbcDataSource datasource, inputSeaLandTableName, inputWaterTableName, epsg ->
             def outputTableName = postfix "INPUT_WATER_SEA_"
             debug 'Merging sea/land mask and water table'
             datasource """ 
                 DROP TABLE if exists ${outputTableName};
                 CREATE TABLE ${outputTableName} (THE_GEOM GEOMETRY(POLYGON, $epsg), id_hydro serial, id_source VARCHAR);
             """
-            if (inputSeaLandTableName && inputWaterTableName ) {
-                if(datasource.firstRow("select count(*) as count from $inputSeaLandTableName where TYPE ='sea'").count>0){
-                def tmp_water_not_in_sea =  "WATER_NOT_IN_SEA${UUID.randomUUID().toString().replaceAll("-", "_")}"
-                //This method is used to merge the SEA mask with the water table
-                def queryMergeWater = """DROP  TABLE IF EXISTS $outputTableName, $tmp_water_not_in_sea;
+            if (inputSeaLandTableName && inputWaterTableName) {
+                if (datasource.firstRow("select count(*) as count from $inputSeaLandTableName where TYPE ='sea'").count > 0) {
+                    def tmp_water_not_in_sea = "WATER_NOT_IN_SEA${UUID.randomUUID().toString().replaceAll("-", "_")}"
+                    //This method is used to merge the SEA mask with the water table
+                    def queryMergeWater = """DROP  TABLE IF EXISTS $outputTableName, $tmp_water_not_in_sea;
                 CREATE TABLE $tmp_water_not_in_sea AS SELECT a.the_geom, a.ID_SOURCE FROM $inputWaterTableName AS a, $inputSeaLandTableName  AS b
                 WHERE b."TYPE"= 'land' AND a.the_geom && b.the_geom AND st_contains(b.THE_GEOM, st_pointonsurface(a.THE_GEOM));
                 CREATE TABLE $outputTableName(the_geom GEOMETRY, ID_HYDRO SERIAL, ID_SOURCE VARCHAR) AS SELECT the_geom, NULL, id_source FROM $tmp_water_not_in_sea UNION ALL 
                 SELECT THE_GEOM, NULL, '-1' FROM $inputSeaLandTableName  WHERE
                 "TYPE" ='sea';"""
-                //Check indexes before executing the query
-                datasource.getSpatialTable(inputWaterTableName).the_geom.createSpatialIndex()
-                datasource.getSpatialTable(inputSeaLandTableName).the_geom.createSpatialIndex()
-                datasource.execute queryMergeWater
-                datasource.execute("drop table if exists $tmp_water_not_in_sea;")
-                }
-                else{
+                    //Check indexes before executing the query
+                    datasource.getSpatialTable(inputWaterTableName).the_geom.createSpatialIndex()
+                    datasource.getSpatialTable(inputSeaLandTableName).the_geom.createSpatialIndex()
+                    datasource.execute queryMergeWater
+                    datasource.execute("drop table if exists $tmp_water_not_in_sea;")
+                } else {
                     return [outputTableName: inputWaterTableName]
                 }
             }
             debug 'The sea/land and water tables have been merged'
-            return  [outputTableName: outputTableName]
+            return [outputTableName: outputTableName]
         }
     }
 }
+
+
+    /**
+     * Generate traffic data according the type of roads and references available in
+     * a traffic properties table
+     * If any traffic properties table is set, the process uses a default one.
+     * The parameters of the default table refer to the European Commission Working Group Assessment of Exposure to Noise.
+     * See table Tool 4.5: No heavy vehicle data available
+     *
+     * For each  3 time periods, day (06:00-18:00), evening (ev) (18:00-22:00) and night (22:00-06:00),
+     * estimated traffic variables are  : *
+     * lv_hour = Number of Light Vehicles per hour (mean)
+     * hv_hour = Number of Heavy Vehicles per hour (mean)
+     * Number of hours when the lv_hour and hv_hour are evaluated
+     * lv_speed = Mean speed of Light Vehicles
+     * hv_speed = Mean speed of Heavy Vehicles
+     * percent_lv = percentage of Light Vehicles per road types
+     * percent_hv = percentage of Heavy Vehicles per road types
+     *
+     *
+     * @param datasource A connexion to a DB to load the OSM file
+     * @param roadTableName The road table that contains the WG_AEN types and maxspeed values
+     * @param outputTablePrefix A prefix used to set the name of the output table
+     * @param trafficFile A traffic properties table stored in a SQL file
+     *
+     * @return The name of the road table
+     */
+    IProcess build_traffic_flow() {
+        return create {
+            title "Compute a default traffic data according the WGAEN values"
+            id "traffic_flow"
+            inputs datasource: JdbcDataSource, inputTableName: String, inputZoneEnvelopeTableName: "", epsg: int, jsonFilename: ""
+            outputs outputTableName: String
+            run { datasource, inputTableName, inputZoneEnvelopeTableName, epsg, jsonFilename ->
+                debug('Create the default traffic data')
+                def outputTableName = postfix "TRAFFIC_FLOW"
+                datasource """
+                DROP TABLE IF EXISTS $outputTableName;
+                CREATE TABLE $outputTableName (THE_GEOM GEOMETRY(GEOMETRY, $epsg), ID_ROAD SERIAL, ID_SOURCE VARCHAR, 
+                ROAD_TYPE VARCHAR, SURFACE VARCHAR, ONEWAY BOOLEAN, SLOPE DOUBLE PRECISION,PAVEMENT VARCHAR,
+                DAY_LV_HOUR INTEGER, DAY_HV_HOUR INTEGER, DAY_LV_SPEED INTEGER ,DAY_HV_SPEED INTEGER, 
+                NIGHT_LV_HOUR INTEGER, NIGHT_HV_HOUR INTEGER, NIGHT_LV_SPEED INTEGER, NIGHT_HV_SPEED INTEGER, 
+                EV_LV_HOUR INTEGER,EV_HV_HOUR INTEGER, EV_LV_SPEED INTEGER, EV_HV_SPEED INTEGER);
+                """
+
+                if (inputTableName) {
+                    def paramsDefaultFile = this.class.getResourceAsStream("trafficFlowParams.json")
+                    def traffic_flow_params = parametersMapping(jsonFilename, paramsDefaultFile)
+                    if(!traffic_flow_params){
+                        error "The traffic flow parameters cannot be null"
+                        return
+                    }
+                    def flow_data = traffic_flow_params.flow_data
+                    def flow_period =traffic_flow_params.flow_periods
+                    def maxspeed = traffic_flow_params.maxspeed
+                    def pavements = traffic_flow_params.pavements
+                    def road_types = traffic_flow_params.road_types
+
+                    if(!flow_data){
+                        error "The traffic flow data cannot be null"
+                        return
+                    }
+
+                    if(!flow_period){
+                        error "The traffic flow period cannot be null"
+                        return
+                    }
+
+                    if(!maxspeed){
+                        error "The maxspeed values data cannot be null"
+                        return
+                    }
+
+                    if(!pavements){
+                        error "The CNOSSOS road pavement identifier cannot be null"
+                        return
+                    }
+
+                    if(!road_types){
+                        error "The road type cannot be null"
+                        return
+                    }
+
+                    def speedPattern = Pattern.compile("([0-9]+)( ([a-zA-Z]+))?", Pattern.CASE_INSENSITIVE)
+
+                    //Define the mapping between the values in OSM and those used in the abstract model
+                    def queryMapper = "SELECT "
+                    def inputSpatialTable = datasource."$inputTableName"
+                    if (inputSpatialTable.rowCount > 0) {
+                        def columnNames = inputSpatialTable.columns
+                        columnNames.remove("THE_GEOM")
+
+                        def flatListColumns =  columnNames.inject([]) { result, iter ->
+                            result+= "a.\"$iter\""
+                        }.join(",")
+
+                        if (inputZoneEnvelopeTableName) {
+                            inputSpatialTable.the_geom.createSpatialIndex()
+                            queryMapper += "${flatListColumns}, CASE WHEN st_overlaps(st_force3D(a.the_geom), b.the_geom) " +
+                                    "THEN st_force3D(st_makevalid(st_intersection(st_force3D(a.the_geom), b.the_geom))) " +
+                                    "ELSE st_force3D(a.the_geom) " +
+                                    "END AS the_geom " +
+                                    "FROM " +
+                                    "$inputTableName AS a, $inputZoneEnvelopeTableName AS b " +
+                                    "WHERE " +
+                                    "a.the_geom && b.the_geom "
+                        } else {
+                            queryMapper += "${flatListColumns}, st_force3D(a.the_geom) as the_geom FROM $inputTableName  as a"
+                        }
+                        datasource.withBatch(1000) { stmt ->
+                            datasource.eachRow(queryMapper) { row ->
+                                //Find road type
+                                def road_type = getTrafficRoadType(road_types, columnNames, row)
+                                //Set a default road
+                                if (!road_type) {
+                                    type = "Small main road"
+                                }
+                                int maxspeed_value = getSpeedInKmh(speedPattern, row."maxspeed")
+                                //Find best speed from road type
+                                if (maxspeed_value == -1) {
+                                    maxspeed_value = maxspeed[road_type]
+                                }
+
+                                String onewayValue = row."oneway"
+                                boolean oneway = false;
+                                if (onewayValue && onewayValue == "yes") {
+                                    oneway = true
+                                }
+
+                                String surface = row."surface"
+
+                                def pavement_value = getPavement(pavements, surface)
+
+                                def  traffic_data = getNumberVehiclesPerHour(road_type, oneway, flow_data, flow_period)
+                                Geometry geom = row.the_geom
+                                if (geom) {
+                                    //Explode geometries
+                                    for (int i = 0; i < geom.getNumGeometries(); i++) {
+                                        stmt.addBatch """insert into $outputTableName (THE_GEOM, ID_SOURCE, ROAD_TYPE,
+                                        SURFACE, ONEWAY, SLOPE ,PAVEMENT,
+                                        DAY_LV_HOUR, DAY_HV_HOUR , DAY_LV_SPEED  ,DAY_HV_SPEED , 
+                                        NIGHT_LV_HOUR , NIGHT_HV_HOUR , NIGHT_LV_SPEED , NIGHT_HV_SPEED , 
+                                        EV_LV_HOUR ,EV_HV_HOUR , EV_LV_SPEED , EV_HV_SPEED ) 
+                                        values(ST_GEOMFROMTEXT('${geom.getGeometryN(i)}',$epsg), '${row.id}','${road_type}',
+                                        '${surface}',${oneway},null, '${pavement_value}',
+                                        ${traffic_data.day_lv_hour},${traffic_data.day_hv_hour},${maxspeed_value},${maxspeed_value},
+                                        ${traffic_data.night_lv_hour},${traffic_data.night_hv_hour},${maxspeed_value},${maxspeed_value},
+                                        ${traffic_data.ev_lv_hour},${traffic_data.ev_hv_hour},${maxspeed_value},${maxspeed_value})""".toString()
+                                    }
+                                }
+
+                            }
+                        }
+            datasource.execute """COMMENT ON COLUMN ${outputTableName}."ROAD_TYPE" IS 'Default value road type';
+            COMMENT ON COLUMN ${outputTableName}."DAY_LV_HOUR" IS 'Number of light vehicles per hour for day';
+            COMMENT ON COLUMN ${outputTableName}."DAY_HV_HOUR" IS 'Number of heavy vehicles per hour for day';
+            COMMENT ON COLUMN ${outputTableName}."DAY_LV_SPEED" IS 'Light vehicles speed for day';
+            COMMENT ON COLUMN ${outputTableName}."DAY_HV_SPEED" IS 'Heavy vehicles speed for day';
+            COMMENT ON COLUMN ${outputTableName}."NIGHT_LV_HOUR" IS 'Number of light vehicles per hour for night';
+            COMMENT ON COLUMN ${outputTableName}."NIGHT_HV_HOUR" IS 'Number of heavy vehicles per hour for night';
+            COMMENT ON COLUMN ${outputTableName}."NIGHT_LV_SPEED" IS 'Light vehicles speed for night';
+            COMMENT ON COLUMN ${outputTableName}."NIGHT_HV_SPEED" IS 'Heavy vehicles speed for night';
+            COMMENT ON COLUMN ${outputTableName}."EV_LV_HOUR" IS 'Number of light vehicles per hour for evening';
+            COMMENT ON COLUMN ${outputTableName}."EV_HV_HOUR" IS 'Number of heavy vehicles per hour for evening';
+            COMMENT ON COLUMN ${outputTableName}."EV_LV_SPEED" IS 'Light vehicles speed for evening';
+            COMMENT ON COLUMN ${outputTableName}."EV_HV_SPEED" IS 'Number of heavy vehicles per hour for evening';
+            COMMENT ON COLUMN ${outputTableName}."SLOPE" IS 'Slope (in %) of the road section.'"""
+
+                    }
+                }
+                debug('Roads traffic computed')
+                [outputTableName: outputTableName]
+            }
+        }
+    }
+
+
+/**
+ * Return a pavement identifier according the CNOSSOS-EU specification
+ * @param pavements an array of pavement regarding the osm value
+ * @param surface the surface value defined by OSM
+ * @return a pavement identifier, default is NL05
+ */
+static String getPavement(def pavements, def surface ){
+    String pvmt = "NL05"
+    if(!surface){
+        return pvmt
+    }
+    for(def pavement : pavements){
+        def pavement_key = pavement.key
+        return  pavement_key.value.contains(surface)?pavement_key:pvmt
+    }
+    return pvmt
+}
+
+/**
+ * Compute the number of light and heavy vehicles per hour for the 3 time periods
+ * day (06:00-18:00), evening (ev) (18:00-22:00) and night (22:00-06:00)
+ *
+ * @param type the road type according the table Tool 4.5: No heavy vehicle data available
+ * @param oneway true is only allowed to drive in one direction
+ * @param flow_data static flow data values for a road type
+ * @param flow_period the 3 time periods
+ * @return a Map with the number of vehicules per hour stored in the variables
+ *
+ *  day_lv_hour :  'Number of light vehicles per hour for day'
+ *  day_hv_hour : 'Number of heavy vehicles per hour for day'
+ *  night_lv_hour : 'Number of light vehicles per hour for night'
+ *  night_hv_hour : 'Number of heavy vehicles per hour for night'
+ *  ev_lv_hour : 'Number of light vehicles per hour for evening'
+ *  ev_hv_hour : 'Number of heavy vehicles per hour for evening'
+ *
+ */
+static Map getNumberVehiclesPerHour(def type, boolean oneway, def flow_data, def flow_period){
+    def flow_data_type = flow_data[type]
+    def day_nb_hours = flow_period.day_nb_hours
+    def ev_nb_hours = flow_period.ev_nb_hours
+    def night_nb_hours = flow_period.night_nb_hours
+    def day_lv_hour,day_hv_hour, night_lv_hour,night_hv_hour, ev_lv_hour,ev_hv_hour
+    if(oneway){
+        day_lv_hour = (flow_data_type.day_nb_vh*flow_data_type.day_percent_lv/day_nb_hours)/2
+        day_hv_hour = (flow_data_type.day_nb_vh*flow_data_type.day_percent_hv /day_nb_hours)/2
+        night_lv_hour = (flow_data_type.night_nb_vh*flow_data_type.night_percent_lv /night_nb_hours)/2
+        night_hv_hour =  (flow_data_type.night_nb_vh*flow_data_type.night_percent_hv /night_nb_hours)/2
+        ev_lv_hour =    (flow_data_type.ev_nb_vh*flow_data_type.ev_percent_lv /ev_nb_hours)/2
+        ev_hv_hour = (flow_data_type.ev_nb_vh*flow_data_type.ev_percent_hv /ev_nb_hours)/2
+    }
+    else{
+        day_lv_hour = (flow_data_type.day_nb_vh*flow_data_type.day_percent_lv/day_nb_hours)
+        day_hv_hour = (flow_data_type.day_nb_vh*flow_data_type.day_percent_hv /day_nb_hours)
+        night_lv_hour = (flow_data_type.night_nb_vh*flow_data_type.night_percent_lv /night_nb_hours)
+        night_hv_hour =  (flow_data_type.night_nb_vh*flow_data_type.night_percent_hv /night_nb_hours)
+        ev_lv_hour =  (flow_data_type.ev_nb_vh*flow_data_type.ev_percent_lv /ev_nb_hours)
+        ev_hv_hour = (flow_data_type.ev_nb_vh*flow_data_type.ev_percent_hv /ev_nb_hours)
+    }
+
+    return ["day_lv_hour" : Math.round(day_lv_hour),"day_hv_hour" : Math.round(day_hv_hour),
+            "night_lv_hour":Math.round(night_lv_hour),"night_hv_hour":Math.round(night_hv_hour),
+            "ev_lv_hour": Math.round(ev_lv_hour),"ev_hv_hour":Math.round(ev_hv_hour)]
+
+
+}
+
+/**
+ * Find the road type from the table parameters
+ * @param road_types  a list of road type and osm key value associations
+ * @param columnNames the name of the columns in the put table
+ * @param row the row to process
+ * @return
+ */
+static String getTrafficRoadType(def road_types, def columnNames, def row){
+    String type_key = null
+    for(def road_type : road_types){
+        type_key = road_type.key
+        for(def osmVals : road_type.value){
+            if (columnNames.contains(osmVals.key.toUpperCase())) {
+                def columnValue = row.getString(osmVals.key)
+                if (columnValue != null) {
+                    if(osmVals.value.contains(columnValue.toLowerCase())){
+                        return type_key
+                    }
+                }
+            }
+        }
+    }
+    return type_key
+}
+
+
+/**
+ * Return a maxspeed value expressed in kmh
+ * @param maxspeedValue from OSM
+ * @return
+ */
+static double getSpeedInKmh(def speedPattern, String maxspeedValue){
+    if (!maxspeedValue) return -1
+    def matcher = speedPattern.matcher(maxspeedValue)
+    if (!matcher.matches()) return -1
+
+    def speed = Integer.parseInt(matcher.group(1))
+
+    if (!(matcher.group(3))) return speed
+
+    def type = matcher.group(3).toLowerCase()
+    switch (type) {
+        case "kmh":
+            return speed
+        case "mph":
+            return speed * 1.609
+        default:
+            return -1
+    }
+}
+
 
 
 

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/OSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/OSM.groovy
@@ -16,7 +16,8 @@ class OSM  {
     public static def extractAndCreateGISLayers
     public static def buildGeoclimateLayers
     public static def formatUrbanAreas
-    public static def formatSeaLandMask;
+    public static def formatSeaLandMask
+    public static def build_traffic_flow
     public static def mergeWaterAndSeaLandTables;
     static {
         def formattingForAbstractModel = new FormattingForAbstractModel()
@@ -31,6 +32,7 @@ class OSM  {
         formatImperviousLayer= formattingForAbstractModel.formatImperviousLayer()
         formatUrbanAreas = formattingForAbstractModel.formatUrbanAreas()
         formatSeaLandMask = formattingForAbstractModel.formatSeaLandMask()
+        build_traffic_flow= formattingForAbstractModel.build_traffic_flow()
         mergeWaterAndSeaLandTables = formattingForAbstractModel.mergeWaterAndSeaLandTables()
         createGISLayers  = osmGISLayers.createGISLayers()
         extractAndCreateGISLayers  = osmGISLayers.extractAndCreateGISLayers()

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
@@ -1096,6 +1096,9 @@ def extractProcessingParameters(def processing_parameters){
             }
         }
 
+        //Check for traffic_flow method
+        def  traffic_flow = processing_parameters.traffic_flow
+
         return defaultParameters
     }
     else{

--- a/osm/src/main/resources/org/orbisgis/orbisprocess/geoclimate/osm/trafficFlowParams.json
+++ b/osm/src/main/resources/org/orbisgis/orbisprocess/geoclimate/osm/trafficFlowParams.json
@@ -1,0 +1,163 @@
+{
+  "flow_data": {
+    "Motorway": {
+      "day_nb_vh": 26103,
+      "ev_nb_vh": 7458,
+      "night_nb_vh": 3729,
+      "day_percent_hv": 0.25,
+      "ev_percent_hv": 0.35,
+      "night_percent_hv": 0.45,
+      "day_percent_lv": 0.75,
+      "ev_percent_lv": 0.65,
+      "night_percent_lv": 0.55
+    },
+    "Trunk roads": {
+      "day_nb_vh": 17936,
+      "ev_nb_vh": 3826,
+      "night_nb_vh": 2152,
+      "day_percent_hv": 0.2,
+      "ev_percent_hv": 0.2,
+      "night_percent_hv": 0.2,
+      "day_percent_lv": 0.8,
+      "ev_percent_lv": 0.8,
+      "night_percent_lv": 0.8
+    },
+    "Main roads": {
+      "day_nb_vh": 7124,
+      "ev_nb_vh": 1069,
+      "night_nb_vh": 712,
+      "day_percent_hv": 0.2,
+      "ev_percent_hv": 0.15,
+      "night_percent_hv": 0.1,
+      "day_percent_lv": 0.8,
+      "ev_percent_lv": 0.85,
+      "night_percent_lv": 0.9
+    },
+    "Small main roads": {
+      "day_nb_vh": 1400,
+      "ev_nb_vh": 400,
+      "night_nb_vh": 200,
+      "day_percent_hv": 0.15,
+      "ev_percent_hv": 0.1,
+      "night_percent_hv": 0.05,
+      "day_percent_lv": 0.85,
+      "ev_percent_lv": 0.9,
+      "night_percent_lv": 0.95
+    },
+    "Collecting roads": {
+      "day_nb_vh": 700,
+      "ev_nb_vh": 200,
+      "night_nb_vh": 100,
+      "day_percent_hv": 0.1,
+      "ev_percent_hv": 0.06,
+      "night_percent_hv": 0.03,
+      "day_percent_lv": 0.9,
+      "ev_percent_lv": 0.94,
+      "night_percent_lv": 0.97
+    },
+    "Service roads": {
+      "day_nb_vh": 350,
+      "ev_nb_vh": 100,
+      "night_nb_vh": 50,
+      "day_percent_hv": 0.05,
+      "ev_percent_hv": 0.02,
+      "night_percent_hv": 0.01,
+      "day_percent_lv": 0.95,
+      "ev_percent_lv": 0.98,
+      "night_percent_lv": 0.99
+    },
+    "Dead-end roads": {
+      "day_nb_vh": 175,
+      "ev_nb_vh": 50,
+      "night_nb_vh": 25,
+      "day_percent_hv": 0.02,
+      "ev_percent_hv": 0.01,
+      "night_percent_hv": 0,
+      "day_percent_lv": 0.98,
+      "ev_percent_lv": 0.99,
+      "night_percent_lv": 1
+    }
+  },
+  "flow_periods": {
+    "day_nb_hours": 12,
+    "ev_nb_hours": 4,
+    "night_nb_hours": 8
+  },
+  "maxspeed": {
+    "Motorway": 130,
+    "Trunk roads": 110,
+    "Main roads": 80,
+    "Small main roads": 80,
+    "Collecting roads": 50,
+    "Service roads": 30,
+    "Dead-end roads": 30
+  },
+  "pavements": {
+    "NL05": null,
+    "NL05": "asphalt",
+    "NL08": [
+      "concrete",
+      "wood",
+      "grass",
+      "sand",
+      "earth",
+      "ground",
+      "sett",
+      "mud",
+      "dirt",
+      "unpaved",
+      "compacted",
+      "gravel",
+      "fine_gravel"
+    ],
+    "NL10": [
+      "paved",
+      "paving_stones",
+      "cobblestone"
+    ]
+  },
+  "road_types": {
+    "Motorway": {
+      "highway": [
+        "motorway",
+        "motorway_link"
+      ]
+    },
+    "Trunk roads": {
+      "highway": [
+        "trunk",
+        "trunk_link"
+      ]
+    },
+    "Main roads": {
+      "highway": [
+        "primary",
+        "primary_link"
+      ]
+    },
+    "Small main roads": {
+      "highway": [
+        "secondary",
+        "secondary_link"
+      ]
+    },
+    "Collecting roads": {
+      "highway": [
+        "tertiary",
+        "tertiary_link",
+        "unclassified"
+      ]
+    },
+    "Service roads": {
+      "highway": [
+        "residential"
+      ]
+    },
+    "Dead-end roads": {
+      "highway": [
+        "service",
+        "living_street"
+      ]
+    }
+  }
+}

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
@@ -152,6 +152,63 @@ class FormattingForAbstractModelTests {
 
         assertNotNull h2GIS.getTable(format.results.outputTableName).save("./target/osm_road_traffic.shp", true)
         assertEquals 211, h2GIS.getTable(format.results.outputTableName).rowCount
+        assertTrue h2GIS.firstRow("select count(*) as count from ${format.results.outputTableName} where road_type is not null").count==211
+
+        def traffic_flow = h2GIS.firstRow("select * from ${format.results.outputTableName} where road_type = 'Collecting roads' limit 1")
+
+        def expectedFlow = [ROAD_TYPE:'Collecting roads',SURFACE:'asphalt',PAVEMENT:'NL05' , DIRECTION:3, DAY_LV_HOUR : 53, DAY_HV_HOUR : 6, DAY_LV_SPEED : 50  ,
+                            DAY_HV_SPEED  : 50, NIGHT_LV_HOUR :12, NIGHT_HV_HOUR :0, NIGHT_LV_SPEED :50, NIGHT_HV_SPEED :50,
+                            EV_LV_HOUR:47 ,EV_HV_HOUR :3, EV_LV_SPEED:50, EV_HV_SPEED:50 ]
+        traffic_flow.each {it ->
+            if(expectedFlow.get(it.key)) {
+                assertEquals(expectedFlow.get(it.key), it.value)
+            }
+        }
+
+        traffic_flow = h2GIS.firstRow("select * from ${format.results.outputTableName} where road_type = 'Dead-end roads' limit 1")
+
+        expectedFlow = [ROAD_TYPE:'Dead-end roads',SURFACE:null,PAVEMENT:'NL05' , DIRECTION:1, DAY_LV_HOUR : 7, DAY_HV_HOUR : 0, DAY_LV_SPEED : 30  ,
+                            DAY_HV_SPEED  : 30, NIGHT_LV_HOUR :2, NIGHT_HV_HOUR :0, NIGHT_LV_SPEED :30, NIGHT_HV_SPEED :30,
+                            EV_LV_HOUR:6 ,EV_HV_HOUR :0, EV_LV_SPEED:30, EV_HV_SPEED:30 ]
+        traffic_flow.each {it ->
+            if(expectedFlow.get(it.key)) {
+                assertEquals(expectedFlow.get(it.key), it.value)
+            }
+        }
+
+        traffic_flow = h2GIS.firstRow("select * from ${format.results.outputTableName} where road_type = 'Service roads' limit 1")
+
+        expectedFlow = [ROAD_TYPE:'Service roads',SURFACE:'asphalt',PAVEMENT:'NL05' , DIRECTION:3, DAY_LV_HOUR : 28, DAY_HV_HOUR : 1, DAY_LV_SPEED : 50  ,
+                        DAY_HV_SPEED  : 50, NIGHT_LV_HOUR :6, NIGHT_HV_HOUR :0, NIGHT_LV_SPEED :50, NIGHT_HV_SPEED :50,
+                        EV_LV_HOUR:25 ,EV_HV_HOUR :1, EV_LV_SPEED:50, EV_HV_SPEED:50 ]
+        traffic_flow.each {it ->
+            if(expectedFlow.get(it.key)) {
+                assertEquals(expectedFlow.get(it.key), it.value)
+            }
+        }
+
+        traffic_flow = h2GIS.firstRow("select * from ${format.results.outputTableName} where road_type = 'Small main roads' limit 1")
+
+        expectedFlow = [ROAD_TYPE:'Small main roads',SURFACE:'asphalt',PAVEMENT:'NL05' , DIRECTION:3, DAY_LV_HOUR : 99, DAY_HV_HOUR : 18, DAY_LV_SPEED : 30  ,
+                        DAY_HV_SPEED  : 30, NIGHT_LV_HOUR :24, NIGHT_HV_HOUR :1, NIGHT_LV_SPEED :30, NIGHT_HV_SPEED :30,
+                        EV_LV_HOUR:90 ,EV_HV_HOUR :10, EV_LV_SPEED:30, EV_HV_SPEED:30 ]
+        traffic_flow.each {it ->
+            if(expectedFlow.get(it.key)) {
+                assertEquals(expectedFlow.get(it.key), it.value)
+            }
+        }
+
+        traffic_flow = h2GIS.firstRow("select * from ${format.results.outputTableName} where road_type = 'Main roads' limit 1")
+
+        expectedFlow = [ROAD_TYPE:'Main roads',SURFACE:'asphalt',PAVEMENT:'NL05' , DIRECTION:3, DAY_LV_HOUR : 475, DAY_HV_HOUR :119, DAY_LV_SPEED : 50  ,
+                        DAY_HV_SPEED  : 50, NIGHT_LV_HOUR :80, NIGHT_HV_HOUR :9, NIGHT_LV_SPEED :50, NIGHT_HV_SPEED :50,
+                        EV_LV_HOUR:227 ,EV_HV_HOUR :40, EV_LV_SPEED:50, EV_HV_SPEED:50 ]
+        traffic_flow.each {it ->
+            if(expectedFlow.get(it.key)) {
+                assertEquals(expectedFlow.get(it.key), it.value)
+            }
+        }
+
     }
 
     @Test

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
@@ -1,5 +1,6 @@
 package org.orbisgis.orbisprocess.geoclimate.osm
 
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
@@ -12,10 +13,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 
 class FormattingForAbstractModelTests {
+    static  H2GIS h2GIS
+
+    @BeforeAll
+    static  void loadDb(){
+         h2GIS = H2GIS.open('./target/osm_formating_test;AUTO_SERVER=TRUE')
+    }
 
     @Test
    void formattingGISLayers() {
-        def h2GIS = H2GIS.open('./target/osmdb;AUTO_SERVER=TRUE')
         def epsg =2154
         IProcess extractData = OSM.createGISLayers
         extractData.execute([
@@ -213,7 +219,6 @@ class FormattingForAbstractModelTests {
 
     @Test
     void extractSeaLandTest(TestInfo testInfo) {
-        def h2GIS = H2GIS.open('./target/sea_land;AUTO_SERVER=TRUE')
         def epsg =32629
         def osmBbox = [52.08484801362273, -10.75003575696209, 52.001518013622736, -10.66670575696209]
         def geom = Utilities.geometryFromNominatim(osmBbox)
@@ -402,8 +407,6 @@ class FormattingForAbstractModelTests {
      * @param zoneToExtract
      */
     void createGISLayersCheckHeight(def zoneToExtract) {
-        def h2GIS = H2GIS.open('./target/osmdb;AUTO_SERVER=TRUE')
-
         IProcess extractData = OSM.extractAndCreateGISLayers
         extractData.execute([
                 datasource : h2GIS,
@@ -435,7 +438,6 @@ class FormattingForAbstractModelTests {
 
     @Test
     void formattingGISBuildingLayer() {
-        def h2GIS = H2GIS.open('./target/osmdb;AUTO_SERVER=TRUE')
         def epsg = 2154
         IProcess extractData = OSM.createGISLayers
         extractData.execute([

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/FormattingForAbstractModelTests.groovy
@@ -141,6 +141,17 @@ class FormattingForAbstractModelTests {
                 inputZoneEnvelopeTableName: "",
                 epsg: epsg])
         assertEquals(0, h2GIS.getTable(format.results.outputTableName).getRowCount())
+
+        //Build traffic data
+        format = OSM.build_traffic_flow
+        format.execute([
+                datasource : h2GIS,
+                inputTableName: extractData.results.roadTableName,
+                epsg: epsg,
+                jsonFilename: null])
+
+        assertNotNull h2GIS.getTable(format.results.outputTableName).save("./target/osm_road_traffic.shp", true)
+        assertEquals 211, h2GIS.getTable(format.results.outputTableName).rowCount
     }
 
     @Test

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/OSMGISLayersTests.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/OSMGISLayersTests.groovy
@@ -1,5 +1,6 @@
 package org.orbisgis.orbisprocess.geoclimate.osm
 
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
@@ -13,10 +14,16 @@ class OSMGISLayersTests {
 
     private static final Logger logger = LoggerFactory.getLogger(OSMGISLayersTests.class)
 
+    static  H2GIS h2GIS
+
+    @BeforeAll
+    static  void loadDb(){
+        h2GIS = H2GIS.open('./target/osm_gislayers_test;AUTO_SERVER=TRUE')
+    }
+
     @Disabled //enable it to test data extraction from the overpass api
     @Test
     void extractAndCreateGISLayers() {
-        def h2GIS = H2GIS.open('./target/osmdb_gislayers;AUTO_SERVER=TRUE')
         IProcess process = OSM.extractAndCreateGISLayers
         process.execute([
                 datasource : h2GIS,
@@ -30,7 +37,6 @@ class OSMGISLayersTests {
 
     @Test
     void createGISLayersTest() {
-        def h2GIS = H2GIS.open('./target/osmdb;AUTO_SERVER=TRUE')
         IProcess process = OSM.createGISLayers
         def osmfile = new File(this.class.getResource("redon.osm").toURI()).getAbsolutePath()
         process.execute([

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -745,6 +745,34 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
     }
 
+
+    @Test
+    void testTrafficFlow() {
+        String directory ="./target/geoclimate_chain_grid"
+        File dirFile = new File(directory)
+        dirFile.delete()
+        dirFile.mkdir()
+        def osm_parmeters = [
+                "description" :"Example of configuration file to run only the estimated height model",
+                "geoclimatedb" : [
+                        "folder" : "${dirFile.absolutePath}",
+                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete" :false
+                ],
+                "input" : [
+                        "osm" : ["Pont-de-Veyle"]],
+                "output" :[
+                        "folder" : ["path": "$directory",
+                                    "tables": ["traffic_flow"]]],
+                "parameters":
+                        ["traffic_flow" : true]
+        ]
+        IProcess process = OSM.workflow
+        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
+        assertTrue h2gis.firstRow("select count(*) as count from traffic_flow where road_type is not null").count>0
+    }
+
     /**
      * Create a configuration file
      * @param osmParameters
@@ -831,6 +859,5 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                 FROM $outputTableStats AS a, $outputTable b WHERE a.id_rsu=b.id_rsu GROUP BY b.id_rsu"""
 
         datasource.save("stats_rsu", './target/stats_rsu.shp', true)
-
     }
 }


### PR DESCRIPTION
Add traffic flow estimation for osm data based on the table "Tool 2.5" from the Good Practice Guide for Strategic Noise Mapping and the Production of Associated Data on Noise Exposure Version 2 13th January 2006.
The input table values will be updated asap thanks to [bruitparif](https://www.bruitparif.fr/).
