### PR TITLE
Add method to compute the primary lcz on a grid

### DIFF
--- a/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
@@ -1106,6 +1106,8 @@ def extractProcessingParameters(def processing_parameters){
                                                   "height_of_roughness_elements"   : 6,
                                                   "terrain_roughness_length"       : 0.5],
                                  urbanTypoModelName: "URBAN_TYPOLOGY_BDTOPO_V2_RF_2_1.model"]
+    defaultParameters.put("rsu_indicators", rsu_indicators_default)
+
     if(processing_parameters){
         def distanceP =  processing_parameters.distance
         if(distanceP && distanceP in Number){
@@ -1176,10 +1178,8 @@ def extractProcessingParameters(def processing_parameters){
                     rsu_indicators_default.mapOfWeights = mapOfWeightsP
                 }
             }
-            defaultParameters.put("rsu_indicators", rsu_indicators_default)
         }else{
             rsu_indicators=rsu_indicators_default
-            defaultParameters.put("rsu_indicators", rsu_indicators_default)
         }
         //Check for grid indicators
         def  grid_indicators = processing_parameters.grid_indicators

--- a/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
@@ -163,9 +163,9 @@ IProcess workflow() {
                 //Default H2GIS database properties
                 //Default H2GIS database properties
                 def databaseFolder = System.getProperty("java.io.tmpdir")
-                def databaseName = "bdtopo_v2_2"
-                def databasePath = postfix databaseFolder + File.separator + databaseName
-                def h2gis_properties = ["databaseName": databaseName, "user": "sa", "password": ""]
+                def databaseName = "bdtopo_v2_2"+UUID.randomUUID().toString().replaceAll("-", "_")
+                def databasePath =  databaseFolder + File.separator + databaseName
+                def h2gis_properties = ["databaseName": databasePath, "user": "sa", "password": ""]
                 def delete_h2gis = true
                 def geoclimatedb = parameters.geoclimatedb
                 if (geoclimatedb) {

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
@@ -563,6 +563,41 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
     }
 
     @Test
+    void testWorkFlowWithoutDBConfig() {
+        String directory ="./target/bdtopo_chain_grid_without_db"
+        File dirFile = new File(directory)
+        dirFile.delete()
+        dirFile.mkdir()
+        String dataFolder = getDataFolderPath()
+        def bdTopoParameters = [
+                "description" :"Example of configuration file to run the grid indicators",
+                "input" :["bdtopo_v2":  [
+                        "folder": ["path" :dataFolder,
+                                   "id_zones":[communeToTest]]]],
+                "output" :[
+                        "folder" : ["path": "$directory",
+                                    "tables": ["grid_indicators"]]],
+                "parameters":
+                        ["distance" : 0,
+                         "grid_indicators": [
+                                 "x_size": 1000,
+                                 "y_size": 1000,
+                                 "indicators": ["WATER_FRACTION"]
+                         ],
+                         "rsu_indicators":[
+                                 "indicatorUse": ["LCZ", "UTRF", "TEB"],
+                                 "svfSimplified": true,
+                         ],
+                        ]
+        ]
+        IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
+        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
+        h2gis.load(directory+File.separator+"bdtopo_v2_"+communeToTest+File.separator+"grid_indicators.geojson")
+        assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count>0
+    }
+
+    @Test
     void testWorkFlowGridWithName() {
         String directory ="./target/bdtopo_chain_grid"
         File dirFile = new File(directory)

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GenericIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GenericIndicators.groovy
@@ -1099,7 +1099,7 @@ IProcess upperScaleAreaStatistics() {
             datasource "CREATE INDEX ON $pivotTable ($upperColumnId)"
 
             // Creation of a table which is built from
-            // the union of the grid and pivot tables based on the same cell 'id'
+            // the union of the upperTable and pivot tables based on the same cell 'id'
             def outputTableName = prefix prefixName, "upper_scale_statistics_area"
             def qjoin = """
                         DROP TABLE IF EXISTS $outputTableName;

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GenericIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GenericIndicators.groovy
@@ -1112,7 +1112,7 @@ IProcess upperScaleAreaStatistics() {
             listValues.each {
                 def aliasColumn = "${lowerColumnName}_${it.val.toString().replace('.','_')}"
                 qjoin += """
-                         , NVL($aliasColumn, 0) / ST_AREA(b.$upperGeometryColumn)
+                         , CASE WHEN $aliasColumn IS NULL THEN NULL ELSE $aliasColumn / ST_AREA(b.$upperGeometryColumn) END
                          AS $aliasColumn
                          """
             }

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GenericIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GenericIndicatorsTests.groovy
@@ -585,7 +585,7 @@ class GenericIndicatorsTests {
         h2GIS.execute query
 
         def values= h2GIS.firstRow "select count(*) as nb from babeth_zone where sum_indic=0"
-        assertEquals(2, values.NB)
+        assertEquals(1, values.NB)
 
         values= h2GIS.firstRow "select sum_indic as nb from babeth_zone where id=3"
         assertEquals(0.11, values.NB)

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -152,8 +152,8 @@ IProcess workflow() {
                 def output = parameters.get("output")
                 //Default H2GIS database properties
                 def databaseFolder = System.getProperty("java.io.tmpdir")
-                def databaseName = "osm"
-                def databasePath = postfix databaseFolder + File.separator + databaseName
+                def databaseName = "osm"+UUID.randomUUID().toString().replaceAll("-", "_")
+                def databasePath = databaseFolder + File.separator + databaseName
                 def h2gis_properties = ["databaseName": databasePath, "user": "sa", "password": ""]
                 def delete_h2gis = true
                 def geoclimatedb = parameters.get("geoclimatedb")

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -917,6 +917,8 @@ def extractProcessingParameters(def processing_parameters){
                                                   "terrain_roughness_length"       : 0.5],
                                  estimateHeight:false,
                                  urbanTypoModelName: "URBAN_TYPOLOGY_OSM_RF_2_1.model"]
+    defaultParameters.put("rsu_indicators", rsu_indicators_default)
+
     if(processing_parameters){
         def distanceP =  processing_parameters.distance
         if(distanceP && distanceP in Number){
@@ -986,10 +988,8 @@ def extractProcessingParameters(def processing_parameters){
                     rsu_indicators_default.mapOfWeights = mapOfWeightsP
                 }
             }
-            defaultParameters.put("rsu_indicators", rsu_indicators_default)
         }else{
             rsu_indicators=rsu_indicators_default
-            defaultParameters.put("rsu_indicators", rsu_indicators_default)
         }
 
         //Check for grid indicators

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
@@ -1,6 +1,7 @@
 package org.orbisgis.geoclimate.osm
 
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.orbisgis.geoclimate.Geoindicators
@@ -265,7 +266,7 @@ class InputDataFormattingTest {
 
     }
 
-    //@Disabled
+    @Disabled
     @Test
     //enable it to test data extraction from the overpass api
     void extractCreateFormatGISLayers() {

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -609,7 +609,8 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         IProcess process = OSM.WorkflowOSM.workflow()
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
-        assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where LCZ_PRIMARY is not null").count>0
+        assertEquals(5, h2gis.firstRow("select count(*) as count from grid_indicators where LCZ_PRIMARY is not null").count)
+        assertEquals(1,h2gis.firstRow("select count(*) as count from grid_indicators where LCZ_PRIMARY is null").count)
     }
 
     @Test

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -383,7 +383,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         dirFile.delete()
         dirFile.mkdir()
         def osm_parmeters = [
-                "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
+                "description" :"Example of configuration file to run the OSM workflow and store the result in a folder",
                 "geoclimatedb" : [
                         "folder" : "${dirFile.absolutePath}",
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",


### PR DESCRIPTION
A new method has been added in the workflow to compute the primary lcz on a grid.
To activate this method, the user must set the term "LCZ_PRIMARY" in the grid indicators list.

Pseudo config file : 

```
"grid_indicators": [
                                 "x_size": 1000,
                                 "y_size": 1000,
                                 "indicators": ["LCZ_PRIMARY"]
                         ]
```
This PR fixes also the issue #612 