### PR TITLE
BDTopo and OSM workflow now return the name of the computed tables.

### DIFF
--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/InputDataLoadingTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/InputDataLoadingTest.groovy
@@ -1,19 +1,18 @@
 package org.orbisgis.geoclimate.bdtopo_v2
 
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 
 import static org.junit.jupiter.api.Assertions.*
 
 class InputDataLoadingTest {
-    
-    def h2GISDatabase
+
 
     public static communeToTest = "12174"
 
-    @BeforeEach
-    void beforeEach(){
+
+    H2GIS createH2GIS(String dbPath){
         def dataFolderInseeCode = "sample_$communeToTest"
         def listFilesBDTopo = ["COMMUNE", "BATI_INDIFFERENCIE", "BATI_INDUSTRIEL", "BATI_REMARQUABLE",
                                "ROUTE", "SURFACE_EAU", "ZONE_VEGETATION", "ZONE_VEGETATION",
@@ -27,7 +26,7 @@ class InputDataLoadingTest {
                            "ROAD_BD_TOPO_TYPE", "VEGET_ABSTRACT_PARAMETERS", "VEGET_ABSTRACT_TYPE",
                            "VEGET_BD_TOPO_TYPE"]
 
-        h2GISDatabase = H2GIS.open("./target/h2gis_input_data_formating;AUTO_SERVER=TRUE", "sa", "")
+        H2GIS h2GISDatabase = H2GIS.open("./target/${dbPath};AUTO_SERVER=TRUE", "sa", "")
 
         // Load parameter files
         paramTables.each{
@@ -37,10 +36,12 @@ class InputDataLoadingTest {
         listFilesBDTopo.each{
             h2GISDatabase.load(getClass().getResource("$dataFolderInseeCode/${it}.shp"), it, true)
         }
+        return h2GISDatabase
     }
 
     @Test
     void prepareBDTopoDataTest() {
+        def h2GISDatabase =  createH2GIS("prepareBDTopoDataTest")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
                                     tableCommuneName: 'COMMUNE', tableBuildIndifName: 'BATI_INDIFFERENCIE',
@@ -247,6 +248,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_BUILDING table is well produced, despite the absence of the BATI_INDIFFERENCIE table
     @Test
     void importPreprocessBuildIndifTest() {
+        def h2GISDatabase =  createH2GIS("importPreprocessBuildIndifTest")
         h2GISDatabase.execute ("""DROP TABLE IF EXISTS BATI_INDIFFERENCIE""")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -299,6 +301,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_BUILDING table is well produced, despite the absence of the BATI_INDUSTRIEL table
     @Test
     void importPreprocessBuildIndusTest() {
+        def h2GISDatabase =  createH2GIS("importPreprocessBuildIndusTest")
         h2GISDatabase.execute ("""DROP TABLE IF EXISTS BATI_INDUSTRIEL""")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -352,6 +355,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_BUILDING table is well produced, despite the absence of the BATI_REMARQUABLE table
     @Test
     void importPreprocessBuildRemarqTest() {
+        def h2GISDatabase = createH2GIS("importPreprocessBuildRemarqTest")
         h2GISDatabase.execute ("""DROP TABLE IF EXISTS BATI_REMARQUABLE """)
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -405,6 +409,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_ROAD table is well produced, despite the absence of the ROUTE table
     @Test
     void importPreprocessRoadTest() {
+        def h2GISDatabase = createH2GIS("importPreprocessRoadTest")
         h2GISDatabase.execute ("""DROP TABLE IF EXISTS ROUTE""")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -460,6 +465,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_RAIL table is well produced, despite the absence of the TRONCON_VOIE_FERREE table
     @Test
     void importPreprocessRailTest() {
+        def h2GISDatabase = createH2GIS("importPreprocessRailTest")
         h2GISDatabase.execute ("DROP TABLE IF EXISTS TRONCON_VOIE_FERREE;")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -511,6 +517,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_HYDRO table is well produced, despite the absence of the SURFACE_EAU table
     @Test
     void importPreprocessHydroTest() {
+        def h2GISDatabase = createH2GIS("importPreprocessHydroTest")
         h2GISDatabase.execute ("DROP TABLE IF EXISTS SURFACE_EAU;")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -556,6 +563,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_VEGET table is well produced, despite the absence of the ZONE_VEGETATION table
     @Test
     void importPreprocessVegetTest() {
+        def h2GISDatabase = createH2GIS("importPreprocessVegetTest")
         h2GISDatabase.execute ("DROP TABLE IF EXISTS ZONE_VEGETATION;")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -603,6 +611,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_IMPERVIOUS table is well produced, despite the absence of the SURFACE_ACTIVITE table
     @Test
     void importPreprocessImperviousSurfActTest() {
+        def h2GISDatabase =  createH2GIS("importPreprocessImperviousSurfActTest")
         h2GISDatabase.execute ("DROP TABLE IF EXISTS SURFACE_ACTIVITE;")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -656,6 +665,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_IMPERVIOUS table is well produced, despite the absence of the TERRAIN_SPORT table
     @Test
     void importPreprocessImperviousSportTest() {
+        def h2GISDatabase =  createH2GIS("importPreprocessImperviousSportTest")
         h2GISDatabase.execute ("DROP TABLE IF EXISTS TERRAIN_SPORT;")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -709,6 +719,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_IMPERVIOUS table is well produced, despite the absence of the CONSTRUCTION_SURFACIQUE table
     @Test
     void importPreprocessImperviousConstrSurfTest() {
+        def h2GISDatabase = createH2GIS("importPreprocessImperviousConstrSurfTest")
         h2GISDatabase.execute ("DROP TABLE IF EXISTS CONSTRUCTION_SURFACIQUE;")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -762,6 +773,7 @@ class InputDataLoadingTest {
     // Check whether the INPUT_IMPERVIOUS table is well produced, despite the absence of the SURFACE_ROUTE table
     @Test
     void importPreprocessImperviousSurfRoadTest() {
+        def h2GISDatabase =  createH2GIS("importPreprocessImperviousSurfRoadTest")
         h2GISDatabase.execute ("DROP TABLE IF EXISTS SURFACE_ROUTE;")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
@@ -815,6 +827,7 @@ class InputDataLoadingTest {
     // Check that the conversion (to valid) of an invalid building (ID = BATIMENT0000000290122667 from BATI_INDIFFERENCIE) is well done
     @Test
     void checkMakeValidBuildingIndif() {
+        def h2GISDatabase =  createH2GIS("checkMakeValidBuildingIndif")
         def process = BDTopo_V2.InputDataLoading.prepareBDTopoData()
         assertTrue process.execute([datasource: h2GISDatabase,
                                     tableCommuneName: 'COMMUNE', tableBuildIndifName: 'BATI_INDIFFERENCIE',
@@ -840,6 +853,7 @@ class InputDataLoadingTest {
 
     @Test
     void initTypes() {
+        def h2GISDatabase = createH2GIS("initTypes")
         def process = BDTopo_V2.InputDataLoading.initTypes()
         assertTrue process.execute([datasource       : h2GISDatabase, buildingAbstractUseType: 'BUILDING_ABSTRACT_USE_TYPE',
                                     roadAbstractType: 'ROAD_ABSTRACT_TYPE', roadAbstractCrossing: 'ROAD_ABSTRACT_CROSSING',
@@ -984,8 +998,8 @@ class InputDataLoadingTest {
     }
 
     @Test
-    void initParametersAbstract(){
-        H2GIS h2GISDatabase = H2GIS.open("./target/h2gis_abstract_tables_${UUID.randomUUID()};AUTO_SERVER=TRUE", "sa", "")
+    void initParametersAbstract() {
+        def h2GISDatabase =  createH2GIS("initParametersAbstract")
         def process = BDTopo_V2.InputDataLoading.initParametersAbstract()
         assertTrue process.execute([datasource: h2GISDatabase])
         process.getResults().each {entry ->

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
@@ -721,7 +721,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
         assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
-        assertEquals(3,  process.getResults().outputTableNames[communeToTest].size())
+        assertEquals(8,  process.getResults().outputTableNames[communeToTest].size())
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from road_traffic where road_type is null").count==0
     }

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
@@ -302,7 +302,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertFalse(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertFalse(process.execute(input: createConfigFile(bdTopoParameters, directory)))
     }
 
     @Disabled
@@ -351,7 +351,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
     }
 
 
@@ -438,7 +438,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
         //Check if the tables exist and contains at least one row
         outputTables.values().each {it->
             def spatialTable = postGIS.getSpatialTable(it)
@@ -497,7 +497,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
         //Check if the tables exist and contains at least one row
         outputTables.values().each {it->
             def spatialTable = postGIS.getSpatialTable(it)
@@ -540,7 +540,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count>0
     }
@@ -578,7 +578,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE")
         h2gis.load(directory+File.separator+"bdtopo_v2_"+envCoords.join("-")+File.separator+"grid_indicators.geojson")
         assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count>0
@@ -614,7 +614,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count>0
     }
@@ -649,7 +649,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where LCZ_PRIMARY is not null").count>0
     }
@@ -688,7 +688,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where BUILDING_FRACTION>0").count>0
     }
@@ -704,7 +704,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
         def bdTopoParameters = [
                 "description" :"Example of configuration file to build the road traffic",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
@@ -720,8 +720,8 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
-        assertEquals(8,  process.getResults().outputTableNames[communeToTest].size())
+        assertTrue(process.execute(input: bdTopoParameters))
+        assertEquals(8,  process.getResults().output[communeToTest].size())
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from road_traffic where road_type is null").count==0
     }
@@ -815,7 +815,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
         ]
 
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(workflow_parameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(workflow_parameters, directory)))
     }
 
     @Disabled //Use it for integration test with a postgis database
@@ -873,7 +873,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         ]
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
-        assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertTrue(process.execute(input: createConfigFile(bdTopoParameters, directory)))
 
     }
 

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
@@ -721,6 +721,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
         ]
         IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
         assertTrue(process.execute(configurationFile: createConfigFile(bdTopoParameters, directory)))
+        assertEquals(3,  process.getResults().outputTableNames[communeToTest].size())
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from road_traffic where road_type is null").count==0
     }

--- a/geoclimate/src/main/groovy/org/orbisgis/geoclimate/Geoclimate.groovy
+++ b/geoclimate/src/main/groovy/org/orbisgis/geoclimate/Geoclimate.groovy
@@ -71,7 +71,7 @@ class Geoclimate implements Callable<Integer> {
     @Override
     Integer call() {
         if (workflow.trim().equalsIgnoreCase("OSM")) {
-            def success = OSM.workflow.execute(configurationFile: configFile.trim())
+            def success = OSM.workflow.execute(input: configFile.trim())
             if (success) {
                 println("The OSM workflow has been successfully executed")
                 return SUCCESS_CODE
@@ -80,7 +80,7 @@ class Geoclimate implements Callable<Integer> {
                 return PROCESS_FAIL_CODE
             }
         } else if (workflow.trim().equalsIgnoreCase("BDTOPO_V2.2")) {
-            def success = BDTopo_V2.workflow.execute(configurationFile: configFile.trim())
+            def success = BDTopo_V2.workflow.execute(input: configFile.trim())
             if (success) {
                 println("The BDTOPO_V2.2 workflow has been successfully executed")
                 return SUCCESS_CODE

--- a/geoclimate/src/test/groovy/org/orbisgis/geoclimate/GeoclimateTest.groovy
+++ b/geoclimate/src/test/groovy/org/orbisgis/geoclimate/GeoclimateTest.groovy
@@ -93,14 +93,14 @@ class GeoclimateTest {
         def osmParameters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE",
                         "delete" :true
                 ],
                 "input" : [
                         "osm" : ["Pont de veyle"]],
                 "output" :[
-                        "folder" : "$directory"],
+                        "folder" : directory],
                 "parameters":[
                         "rsu_indicators":[
                                 "indicatorUse": ["LCZ"],
@@ -115,13 +115,6 @@ class GeoclimateTest {
                         ]
                 ]
         ]
-        def json = JsonOutput.toJson(osmParameters)
-        def configFile = File.createTempFile("osmConfigFile",".json")
-        if(configFile.exists()){
-            configFile.delete()
-        }
-        configFile.write(json)
-
-        Geoclimate.OSM.workflow.execute(configurationFile: configFile.absolutePath)
+        Geoclimate.OSM.workflow.execute(input: osmParameters)
     }
 }

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/BuildingIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/BuildingIndicators.groovy
@@ -388,14 +388,14 @@ IProcess roadDistance() {
                 CREATE TABLE $build_buffer AS
                     SELECT $ID_FIELD_BU,  ST_BUFFER($GEOMETRIC_FIELD, $bufferDist) AS $GEOMETRIC_FIELD 
                     FROM $inputBuildingTableName;
-                CREATE INDEX IF NOT EXISTS buff_ids ON $build_buffer USING RTREE($GEOMETRIC_FIELD)""".toString()
+                CREATE SPATIAL INDEX IF NOT EXISTS buff_ids ON $build_buffer ($GEOMETRIC_FIELD)""".toString()
             // The road surfaces are created
             datasource """
                 DROP TABLE IF EXISTS $road_surf;
                 CREATE TABLE $road_surf AS 
                     SELECT ST_BUFFER($GEOMETRIC_FIELD, $ROAD_WIDTH::DOUBLE PRECISION/2,'endcap=flat') AS $GEOMETRIC_FIELD 
                     FROM $inputRoadTableName; 
-                CREATE INDEX IF NOT EXISTS buff_ids ON $road_surf USING RTREE($GEOMETRIC_FIELD)""".toString()
+                CREATE SPATIAL INDEX IF NOT EXISTS buff_ids ON $road_surf ($GEOMETRIC_FIELD)""".toString()
             // The roads located within the buffer are identified
             datasource """
                 DROP TABLE IF EXISTS $road_within_buffer; 
@@ -404,7 +404,7 @@ IProcess roadDistance() {
                     FROM $build_buffer a, $road_surf b 
                     WHERE a.$GEOMETRIC_FIELD && b.$GEOMETRIC_FIELD 
                     AND ST_INTERSECTS(a.$GEOMETRIC_FIELD, b.$GEOMETRIC_FIELD); 
-                CREATE INDEX IF NOT EXISTS with_buff_id ON $road_within_buffer USING BTREE($ID_FIELD_BU); """.toString()
+                CREATE INDEX IF NOT EXISTS with_buff_id ON $road_within_buffer ($ID_FIELD_BU); """.toString()
 
             // The minimum distance is calculated between each building and the surrounding roads (the minimum
             // distance is set to the bufferDist value for buildings having no road within a bufferDist meters

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -1023,7 +1023,7 @@ IProcess computeAllGeoIndicators() {
                 urbanTypoModelName: "",
                 buildingHeightModelName: ""
         outputs outputTableBuildingIndicators: String, outputTableBlockIndicators: String,
-                outputTableRsuIndicators: String, outputTableRsuLcz: String, outputTableZone: String,
+                outputTableRsuIndicators: String, outputTableRsuLcz: String, zoneTableName: String,
                 outputTableRsuUrbanTypoArea: String, outputTableRsuUrbanTypoFloorArea: String,
                 outputTableBuildingUrbanTypo: String, buildingTableName :String
         run { datasource, zoneTable, buildingTable, roadTable, railTable, vegetationTable, hydrographicTable,
@@ -1173,7 +1173,7 @@ IProcess computeAllGeoIndicators() {
                                 outputTableBlockIndicators      : relationBlocks,
                                 outputTableRsuIndicators        : relationRSU,
                                 outputTableRsuLcz               : null,
-                                outputTableZone                 : zoneTable,
+                                zoneTableName                   : zoneTable,
                                 outputTableRsuUrbanTypoArea     : null,
                                 outputTableRsuUrbanTypoFloorArea: null,
                                 outputTableBuildingUrbanTypo    : null,
@@ -1464,7 +1464,7 @@ IProcess computeAllGeoIndicators() {
                         outputTableBlockIndicators      : blockIndicators,
                         outputTableRsuIndicators        : computeRSUIndicators.getResults().outputTableName,
                         outputTableRsuLcz               : rsuLcz,
-                        outputTableZone                 : zoneTable,
+                        zoneTableName                   : zoneTable,
                         outputTableRsuUrbanTypoArea     : urbanTypoArea,
                         outputTableRsuUrbanTypoFloorArea: urbanTypoFloorArea,
                         outputTableBuildingUrbanTypo    : urbanTypoBuilding,
@@ -1503,7 +1503,7 @@ IProcess computeAllGeoIndicators() {
  * The LCZ classification  and the urban typology
  *
  * @return 8 tables outputTableBuildingIndicators, outputTableBlockIndicators, outputTableRsuIndicators,
- * outputTableRsuLcz, outputTableZone ,
+ * outputTableRsuLcz, zoneTableName ,
  * outputTableRsuUrbanTypoArea, outputTableRsuUrbanTypoFloorArea,
  * outputTableBuildingUrbanTypo.
  * The first three tables contains the geoindicators and the last tables the LCZ and urban typology classifications.
@@ -1524,7 +1524,7 @@ IProcess computeGeoclimateIndicators() {
                                "height_of_roughness_elements": 1, "terrain_roughness_length": 1],
                 urbanTypoModelName: ""
         outputs outputTableBuildingIndicators: String, outputTableBlockIndicators: String,
-                outputTableRsuIndicators: String, outputTableRsuLcz: String, outputTableZone: String,
+                outputTableRsuIndicators: String, outputTableRsuLcz: String, zoneTableName: String,
                 outputTableRsuUrbanTypoArea: String, outputTableRsuUrbanTypoFloorArea: String,
                 outputTableBuildingUrbanTypo: String
         run { datasource, zoneTable, buildingTable, roadTable, railTable, vegetationTable, hydrographicTable,
@@ -1821,7 +1821,7 @@ IProcess computeGeoclimateIndicators() {
                     outputTableBlockIndicators      : blockIndicators,
                     outputTableRsuIndicators        : rsuIndicators,
                     outputTableRsuLcz               : rsuLcz,
-                    outputTableZone                 : zoneTable,
+                    zoneTableName                   : zoneTable,
                     outputTableRsuUrbanTypoArea     : urbanTypoArea,
                     outputTableRsuUrbanTypoFloorArea: urbanTypoFloorArea,
                     outputTableBuildingUrbanTypo    : urbanTypoBuilding]

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/RsuIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/RsuIndicatorsTests.groovy
@@ -13,11 +13,10 @@ import static org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS.open
 class RsuIndicatorsTests {
 
     private static def h2GIS
-    private static def randomDbName() {"${RsuIndicatorsTests.simpleName}_${UUID.randomUUID().toString().replaceAll"-", "_"}"}
 
     @BeforeAll
     static void beforeAll(){
-        h2GIS = open"./target/${randomDbName()};AUTO_SERVER=TRUE"
+        h2GIS = open"./target/${RsuIndicatorsTests.simpleName}_db;AUTO_SERVER=TRUE"
     }
 
     @BeforeEach

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -1425,7 +1425,6 @@ def abstractModelTableBatchExportTable(JdbcDataSource output_datasource, def out
                         //Collect all values
                         def ouputValues = finalOutputColumns.collectEntries { [it.toLowerCase(), null] }
                         ouputValues.put("id_zone", id_zone)
-                        outputconnection.setAutoCommit(false);
                         output_datasource.withBatch(BATCH_MAX_SIZE, insertTable.toString()) { ps ->
                             inputRes.eachRow { row ->
                                 //Fill the value
@@ -1444,7 +1443,6 @@ def abstractModelTableBatchExportTable(JdbcDataSource output_datasource, def out
                         error("Cannot save the table $output_table.\n", e);
                         return false;
                     } finally {
-                        outputconnection.setAutoCommit(true);
                         info "The table $h2gis_table_to_save has been exported into the table $output_table"
                     }
                 }
@@ -1545,7 +1543,6 @@ def indicatorTableBatchExportTable(def output_datasource, def output_table, def 
                         //Collect all values
                         def ouputValues = finalOutputColumns.collectEntries {[it.toLowerCase(), null]}
                         ouputValues.put("id_zone", id_zone)
-                        outputconnection.setAutoCommit(false);
                             output_datasource.withBatch(BATCH_MAX_SIZE, insertTable.toString()) { ps ->
                                 inputRes.eachRow{ row ->
                                     //Fill the value

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -1353,7 +1353,7 @@ def saveTablesInDatabase(JdbcDataSource output_datasource, JdbcDataSource h2gis_
             , "",inputSRID,outputSRID,reproject)
 
     //Export building_height_missing table
-    def output_table = outputTableNames.buildingHeightMissingTableName
+    def output_table = outputTableNames.building_height_missing
     def h2gis_table_to_save= h2gis_tables.buildingHeightMissingTableName
 
     if(output_table) {

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -438,7 +438,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "folder" : directory]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(input: osm_parmeters, directory))
+        assertTrue(process.execute(input: osm_parmeters))
     }
 
     @Test

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -203,7 +203,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the result into a database",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
@@ -213,7 +213,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "database" :
                                 ["user" : "sa",
                                 "password":"",
-                                 "url": "jdbc:h2://${dirFile.absolutePath+File.separator+"geoclimate_chain_db_output;AUTO_SERVER=TRUE"}",
+                                 "url": "jdbc:h2://"+dirFile.absolutePath+File.separator+"geoclimate_chain_db_output;AUTO_SERVER=TRUE",
                                  "tables": [
                                           "rsu_indicators":"rsu_indicators",
                                           "rsu_lcz":"rsu_lcz" ]]],
@@ -232,7 +232,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: osm_parmeters))
         H2GIS outputdb = H2GIS.open(dirFile.absolutePath+File.separator+"geoclimate_chain_db_output;AUTO_SERVER=TRUE")
         def rsu_indicatorsTable = outputdb.getTable("rsu_indicators")
         assertNotNull(rsu_indicatorsTable)
@@ -251,7 +251,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the result in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE",
                         "delete" :true
                 ],
@@ -280,7 +280,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: osm_parmeters))
         def postgis_dbProperties = [databaseName: 'orbisgis_db',
                                            user        : 'orbisgis',
                                            password    : 'orbisgis',
@@ -315,14 +315,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the results in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : "${directory}",
+                        "folder" : directory,
                         "srid":4326],
                 "parameters":
                         ["distance" : 0,
@@ -331,7 +331,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: osm_parmeters))
         //Test the SRID of all output files
         def geoFiles = []
         def  folder = new File("${directory+File.separator}osm_Pont-de-Veyle")
@@ -356,21 +356,21 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : "$directory"],
+                        "folder" : directory],
                 "parameters":
                         [rsu_indicators: ["indicatorUse": ["LCZ"],
                                           "svfSimplified": true]
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
 
     }
 
@@ -384,17 +384,17 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the result in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
                 "input" : [
                         "osm" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
                 "output" :[
-                        "folder" : "$directory"]
+                        "folder" : directory]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: osm_parmeters))
     }
 
     @Test
@@ -406,17 +406,17 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
                 "input" : [
                         "osm" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
                 "output" :[
-                        "folder" : "$directory"]
+                        "folder" : directory]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
     }
 
     @Test
@@ -428,17 +428,17 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
                 "input" : [
                         "osm" : ["", [-3.0961382389068604, -3.1055688858032227,48.77155634881654,]]],
                 "output" :[
-                        "folder" : "$directory"]
+                        "folder" : directory]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: osm_parmeters, directory))
     }
 
     @Test
@@ -450,14 +450,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : "$directory"],
+                        "folder" : directory],
                 "parameters":
                         ["distance" : 100,
                          "hLevMin": 3,
@@ -490,14 +490,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the results in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : "$directory"],
+                        "folder" : directory],
                 "parameters":
                         ["distance" : 0,
                          rsu_indicators: ["indicatorUse": ["LCZ", "UTRF"],
@@ -518,14 +518,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run only the estimated height model",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : ["path": "$directory",
+                        "folder" : ["path": directory,
                                     "tables": ["building"]]],
                 "parameters":
                         ["distance" : 0,
@@ -550,14 +550,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the grid indicators",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                "folder" : ["path": "$directory",
+                "folder" : ["path": directory,
                     "tables": ["grid_indicators", "zones"]]],
                 "parameters":
                         ["distance" : 0,
@@ -587,14 +587,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the grid indicators",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : ["path": "$directory",
+                        "folder" : ["path": directory,
                                     "tables": ["grid_indicators", "zones", "rsu_lcz"]]],
                 "parameters":
                         ["distance" : 0,
@@ -621,7 +621,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the grid indicators",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
@@ -629,7 +629,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "osm" : [[48.49749,5.25349,48.58082,5.33682]],
                         "delete":true],
                 "output" :[
-                        "folder" : ["path": "$directory",
+                        "folder" : ["path": directory,
                                     "tables": ["grid_indicators", "zones"]]],
                 "parameters":
                         ["distance" : 0,
@@ -656,14 +656,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the result in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_test_integration;AUTO_SERVER=TRUE;",
                         "delete" :false
                 ],
                 "input" : [
                         "osm" : ["Rennes"]],
                 "output" :[
-                        "folder" :"$directory"]
+                        "folder" :directory]
                 ,
                 "parameters":
                         ["distance" : 0,
@@ -696,7 +696,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
@@ -704,7 +704,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "osm" : [[
                                          53.83061, 9.83664, 53.91394, 9.91997
                                  ]]],
-                "output" :["folder" : "$directory",srid: 4326]
+                "output" :["folder" : directory,srid: 4326]
                 ,
                 "parameters":
                         ["distance" : 0,
@@ -738,14 +738,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run the OSM workflow and store the result in a folder",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : "$directory"],
+                        "folder" : directory],
                 "parameters":
                         [
                                 rsu_indicators:[
@@ -769,14 +769,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def osm_parmeters = [
                 "description" :"Example of configuration file to run only the road traffic estimation",
                 "geoclimatedb" : [
-                        "folder" : "${dirFile.absolutePath}",
+                        "folder" : dirFile.absolutePath,
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],
                 "output" :[
-                        "folder" : ["path": "$directory",
+                        "folder" : ["path": directory,
                                     "tables": ["road_traffic"]]],
                 "parameters":
                         ["road_traffic" : true]

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -477,7 +477,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertFalse(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertFalse(process.execute(input: osm_parmeters))
     }
 
     @Disabled
@@ -506,7 +506,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
     }
 
     @Test
@@ -536,7 +536,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count>0
     }
@@ -570,7 +570,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from grid_indicators where water_fraction>0").count>0
         def  grid_file = new File("${directory+File.separator}osm_Pont-de-Veyle${File.separator}grid_indicators_water_fraction.asc")
@@ -606,7 +606,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertEquals(5, h2gis.firstRow("select count(*) as count from grid_indicators where LCZ_PRIMARY is not null").count)
         assertEquals(1,h2gis.firstRow("select count(*) as count from grid_indicators where LCZ_PRIMARY is null").count)
@@ -643,7 +643,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
     }
 
     @Disabled //Use it for debug
@@ -682,7 +682,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
     }
 
 
@@ -725,7 +725,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         ]
 
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
     }
 
 
@@ -756,7 +756,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
     }
 
 
@@ -782,8 +782,8 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ["road_traffic" : true]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
-        assertEquals(3,  process.getResults().outputTableNames["Pont-de-Veyle"].size())
+        assertTrue(process.execute(input: createOSMConfigFile(osm_parmeters, directory)))
+        assertEquals(3,  process.getResults().output["Pont-de-Veyle"].size())
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from road_traffic where road_type is not null").count>0
     }
@@ -811,6 +811,6 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def configFile = getClass().getResource("config/osm_workflow_placename_folderoutput.json").toURI()
         //configFile =getClass().getResource("config/osm_workflow_envelope_folderoutput.json").toURI()
         IProcess process = OSM.WorkflowOSM.workflow()
-        assertTrue(process.execute(configurationFile: configFile))
+        assertTrue(process.execute(input: configFile))
     }
 }

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -220,15 +220,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                 "parameters":
                         ["distance" : 0,
                          rsu_indicators: ["indicatorUse": ["LCZ"],
-                                          "svfSimplified": true,
-                                          "mapOfWeights":
-                                                  ["sky_view_factor": 1,
-                                                   "aspect_ratio": 1,
-                                                   "building_surface_fraction": 1,
-                                                   "impervious_surface_fraction" : 1,
-                                                   "pervious_surface_fraction": 1,
-                                                   "height_of_roughness_elements": 1,
-                                                   "terrain_roughness_length": 1]]
+                                          "svfSimplified": true]
                         ]
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
@@ -252,8 +244,8 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                 "description" :"Example of configuration file to run the OSM workflow and store the result in a folder",
                 "geoclimatedb" : [
                         "folder" : dirFile.absolutePath,
-                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE",
-                        "delete" :true
+                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
+                        "delete" :false
                 ],
                 "input" : [
                         "osm" : ["Pont-de-Veyle"]],

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -7,7 +7,6 @@ import org.orbisgis.geoclimate.Geoindicators
 import org.orbisgis.orbisdata.datamanager.jdbc.h2gis.H2GIS
 import org.orbisgis.orbisdata.datamanager.jdbc.postgis.POSTGIS
 import org.orbisgis.orbisdata.processmanager.api.IProcess
-import org.slf4j.Logger
 
 import static org.junit.jupiter.api.Assertions.*
 
@@ -784,6 +783,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         ]
         IProcess process = OSM.WorkflowOSM.workflow()
         assertTrue(process.execute(configurationFile: createOSMConfigFile(osm_parmeters, directory)))
+        assertEquals(3,  process.getResults().outputTableNames["Pont-de-Veyle"].size())
         H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
         assertTrue h2gis.firstRow("select count(*) as count from road_traffic where road_type is not null").count>0
     }


### PR DESCRIPTION
The method getResults() on the OSM and BDTopo workflow returns the name of the computed tables and stored in the local database.
The input parameter has been improved. So the user can send a configuration file or a map to the workflow.

```java
 def osm_parmeters = [
                "description" :"Example of configuration file to run the grid indicators",
                "geoclimatedb" : [
                        "folder" : "/tmp/geoclimate",
                        "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                        "delete" :false
                ],
                "input" : [
                        "osm" : ["Paimpol"]],
                "output" :[
                        "folder" : ["path":  "/tmp/geoclimate",
                                    "tables": ["grid_indicators", "zones", "rsu_lcz"]]],
                "parameters":
                        ["distance" : 0,
                         "grid_indicators": [
                                 "x_size": 1000,
                                 "y_size": 1000,
                                 "indicators": ["LCZ_PRIMARY"]
                         ]
                        ]
        ]
IProcess process = OSM.WorkflowOSM.workflow()
process.execute(input: osm_parmeters)
process.getResults().output["Pont-de-Veyle"]
```
will return a map with a key = Pont-de-Veyle and value = name of tables

If the local H2GIS is not deleted after the workflow chain, the user can process the tables stored in the database.