### PR TITLE
Fix geoclimate dependencies

### DIFF
--- a/geoclimate/pom.xml
+++ b/geoclimate/pom.xml
@@ -53,6 +53,36 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.orbisgis.orbisdata.datamanager</groupId>
+            <artifactId>jdbc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.orbisgis.orbisdata.processmanager</groupId>
+            <artifactId>process</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.orbisgis.geoclimate</groupId>
+            <artifactId>osmtools</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
On the GeoClimate CLI some dependencies cannot be resolved with 

```
@GrabResolver(name='orbisgis', root='https://oss.sonatype.org/content/repositories/snapshots')
@Grab(group='org.orbisgis.geoclimate', module='geoclimate', version='0.0.2-SNAPSHOT')
```

```
Exception thrown

java.lang.RuntimeException: Error grabbing Grapes -- [unresolved dependency: com.h2database#h2;: not found]

	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)

	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```