### PR TITLE
Workflow osm parameters

### DIFF
--- a/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
@@ -45,12 +45,12 @@ import java.sql.SQLException
  *     },
  * [ONE ENTRY REQUIRED]   "input" : {
  *         "folder": {"path" :"path of the folder that contains the BD Topo layers as shapefile",
- *             "id_zones":["56260"]}, //list of insee code, with a comma separator
+ *             "locations":["56260"]}, //list of insee code, with a comma separator
  *          "database": {
  *             "user": "-",
  *             "password": "-",
  *             "url": "jdbc:postgresql://", //JDBC url to connect with the database
- *             "id_zones":["56220"], //list of insee code, with a comma separator
+ *             "locations":["56220"], //list of insee code, with a comma separator
  *             //List of BDTOPO tables required to compute the geoclimate indicators
  *             //Pattern :  Catalog.Schema.Table
  *             "tables": {
@@ -209,13 +209,8 @@ IProcess workflow() {
                     }
                 }
                 if (inputParameters) {
-                    def isbdTopo_v2 = inputParameters.bdtopo_v2
-                    if(!isbdTopo_v2){
-                        error "The input datasource must be defined with the name bdtopo_v2"
-                        return
-                    }
-                    def inputDataBase = isbdTopo_v2.database
-                    def inputFolder = isbdTopo_v2.folder
+                    def inputDataBase = inputParameters.database
+                    def inputFolder = inputParameters.folder
                     def id_zones = []
                     if (inputFolder && inputDataBase) {
                         error "Please set only one input data provider"
@@ -227,7 +222,7 @@ IProcess workflow() {
                                 error "The input folder $inputFolderPath cannot be null or empty"
                                 return
                             }
-                            id_zones = inputFolder.id_zones
+                            id_zones = inputFolder.locations
                         }
                         if (output) {
                             def geoclimateTableNames = ["building_indicators",
@@ -476,7 +471,7 @@ IProcess workflow() {
                                     outputTableNames = null
                                 }
                                 def finalOutputTables = outputTableNames.subMap(allowedOutputTableNames)
-                                def codes = inputDataBase.id_zones
+                                def codes = inputDataBase.locations
                                 if (codes && codes in Collection) {
                                     def inputTableNames = inputDataBase.tables
                                     def h2gis_datasource = H2GIS.open(h2gis_properties)
@@ -580,7 +575,7 @@ IProcess workflow() {
                                     return null
                                 }
                                 if (file_outputFolder.canWrite()) {
-                                    def codes = inputDataBase.id_zones
+                                    def codes = inputDataBase.locations
                                     if (codes && codes in Collection) {
                                         def inputTableNames = inputDataBase.tables
                                         def h2gis_datasource = H2GIS.open(h2gis_properties)
@@ -625,7 +620,7 @@ IProcess workflow() {
                                         allowedOutputTableNames.size()
                                 if (allowedOutputTableNames && !notSameTableNames) {
                                     def finalOutputTables = outputTableNames.subMap(allowedOutputTableNames)
-                                    def codes = inputDataBase.id_zones
+                                    def codes = inputDataBase.locations
                                     if (codes && codes in Collection) {
                                         def inputTableNames = inputDataBase.tables
                                         def h2gis_datasource = H2GIS.open(h2gis_properties)

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
@@ -270,9 +270,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "bdtopo_workflow_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
-                "input" : ["bdtopo_v2": [
+                "input" : [
                         "folder": ["path" :".../processingChain",
-                                   "id_zones":["56350"]]]],
+                                   "locations":["56350"]]],
                 "output" :[
                         "database" :
                                 ["user" : "sa",
@@ -319,9 +319,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "bdtopo_workflow_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
-                "input" :["bdtopo_v2":  [
+                "input" :[
                         "folder": ["path" :".../processingChain",
-                            "id_zones":["-", "-"]]]],
+                            "locations":["-", "-"]]],
                 "output" :[
                         "database" :
                                 ["user" : "sa",
@@ -416,9 +416,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "bdtopo_workflow_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
-                "input" : ["bdtopo_v2": [
+                "input" : [
                         "folder": ["path" :dataFolder,
-                                   "id_zones":[communeToTest]]]],
+                                   "locations":[communeToTest]]],
                 "output" :[
                         "database" :
                                 ["user" : postgis_dbProperties.user,
@@ -473,9 +473,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "bdtopo_workflow_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
-                "input" : ["bdtopo_v2": [
+                "input" : [
                         "folder": ["path" :dataFolder,
-                                   "id_zones":[[env.getMinY(), env.getMinX(), env.getMaxY(), env.getMaxX()]]]]],
+                                   "locations":[[env.getMinY(), env.getMinX(), env.getMaxY(), env.getMaxX()]]]],
                 "output" :[
                         "database" :
                                 ["user" : postgis_dbProperties.user,
@@ -520,9 +520,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
-                "input" :["bdtopo_v2":  [
+                "input" :[
                         "folder": ["path" :dataFolder,
-                                   "id_zones":[communeToTest]]]],
+                                   "locations":[communeToTest]]],
                 "output" :[
                         "folder" : ["path": "$directory",
                                     "tables": ["grid_indicators"]]],
@@ -558,9 +558,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
         def envCoords = [env.getMinY(), env.getMinX(), env.getMaxY(), env.getMaxX()]
         def bdTopoParameters = [
                 "description" :"Example of configuration file to run the grid indicators",
-                "input" :["bdtopo_v2":  [
+                "input" :[
                         "folder": ["path" :dataFolder,
-                                   "id_zones":[envCoords]]]],
+                                   "locations":[envCoords]]],
                 "output" :[
                         "folder" : ["path": "$directory",
                                     "tables": ["grid_indicators"]]],
@@ -598,9 +598,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
-                "input" :["bdtopo_v2":  [
+                "input" :[
                         "folder": ["path" :dataFolder,
-                                   "id_zones":["Olemps"]]]],
+                                   "locations":["Olemps"]]],
                 "output" :[
                         "folder" : ["path": "$directory",
                                     "tables": ["grid_indicators"]]],
@@ -633,9 +633,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
-                "input" :["bdtopo_v2":  [
+                "input" :[
                         "folder": ["path" :dataFolder,
-                                   "id_zones":["Olemps"]]]],
+                                   "locations":["Olemps"]]],
                 "output" :[
                         "folder" : ["path": "$directory",
                                     "tables": ["grid_indicators"]]],
@@ -671,9 +671,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
-                "input" :["bdtopo_v2":  [
+                "input" :[
                         "folder": ["path" :dataFolder,
-                                   "id_zones":[[env.getMinY(), env.getMinX(), env.getMaxY(), env.getMaxX()]]]]],
+                                   "locations":[[env.getMinY(), env.getMinX(), env.getMaxY(), env.getMaxX()]]]],
                 "output" :[
                         "folder" : ["path": "$directory",
                                     "tables": ["grid_indicators"]]],
@@ -708,9 +708,9 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete" :false
                 ],
-                "input" :["bdtopo_v2":  [
+                "input" :[
                         "folder": ["path" :dataFolder,
-                                   "id_zones":[communeToTest]]]],
+                                   "locations":[communeToTest]]],
                 "output" :[
                         "folder" : ["path": "$directory",
                                     "tables": ["road_traffic"]]],
@@ -736,18 +736,18 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
         def user = ""
         def password = ""
         def url = ""
-        def id_zones = ["56223", "44185"]
+        def locations = ["56223", "44185"]
         def local_database_name="paendora_${System.currentTimeMillis()}"
 
         /*================================================================================
         * Input database and tables
         */
-        def  input = ["bdtopo_v2": [
+        def  input = [
                 "database": [
                         "user":user,
                         "password": password,
                         "url": url,
-                        "id_zones":id_zones,
+                        "locations":locations,
                         "tables": ["commune":"ign_bdtopo_2017.commune",
                                    "bati_indifferencie":"ign_bdtopo_2017.bati_indifferencie",
                                    "bati_industriel":"ign_bdtopo_2017.bati_industriel",
@@ -761,7 +761,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                                    "surface_route":"ign_bdtopo_2017.surface_route",
                                    "surface_activite":"ign_bdtopo_2017.surface_activite",
                                    "piste_aerodrome":"ign_bdtopo_2017.piste_aerodrome"]
-                ]]]
+                ]]
 
 
         /*================================================================================
@@ -825,7 +825,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
         def password = ""
         def url = "jdbc:postgresql://x:5432/x"
 
-        def id_zones = [[6785161.292786511,346264.052218681,6794396.60947986,356288.94475984486], "56223"]
+        def locations = [[6785161.292786511,346264.052218681,6794396.60947986,356288.94475984486], "56223"]
         String directory ="./target/bdtopo_workflow_postgis_input"
         File dirFile = new File(directory)
         dirFile.delete()
@@ -837,12 +837,12 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                         "name" : "bdtopo_workflow_db;AUTO_SERVER=TRUE",
                         "delete" :true
                 ],
-                "input" : ["bdtopo_v2": [
+                "input" : [
                         "database": [
                                 "user":user,
                                 "password": password,
                                 "url": url,
-                                "id_zones":id_zones,
+                                "locations":locations,
                                 "tables": ["commune":"ign_bdtopo_2017.commune",
                                            "bati_indifferencie":"ign_bdtopo_2017.bati_indifferencie",
                                            "bati_industriel":"ign_bdtopo_2017.bati_industriel",
@@ -856,7 +856,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                                            "surface_route":"ign_bdtopo_2017.surface_route",
                                            "surface_activite":"ign_bdtopo_2017.surface_activite",
                                            "piste_aerodrome":"ign_bdtopo_2017.piste_aerodrome"]
-                        ]]],
+                        ]],
                 "output" :[
                         "folder" : ["path": "$directory"]],
                 "parameters":

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/RsuIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/RsuIndicators.groovy
@@ -1551,7 +1551,6 @@ IProcess surfaceFractions() {
             }
             //Cache the table name to re-use it
             cacheTableName(BASE_TABLE_NAME, outputTableName)
-
             [outputTableName: outputTableName]
         }
     }

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -1972,9 +1972,9 @@ IProcess rasterizeIndicators() {
                     }
                 }
 
-
                 // Calculate all surface fractions indicators on the GRID cell
                 // Need to create the smallest geometries used as input of the surface fraction process
+
                 def columnFractionsList = [:]
                 def priorities = ["water", "building", "high_vegetation", "low_vegetation", "road", "impervious"]
 

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -50,11 +50,11 @@ import org.orbisgis.geoclimate.Geoindicators
  *  *         "delete" :false
  *  *     },
  *  * [REQUIRED]   "input" : {
- *  *            "osm" : ["filter"] // OSM filter to extract the data. Can be a place name supported by nominatim
+ *  *            "location" : ["filter"] // OSM filter to extract the data. Can be a place name supported by nominatim
  *                                  // e.g "osm" : ["oran", "plourivo"]
  *                                  // or bbox expressed as "osm" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]
  *  *           "all":true //optional value if the user wants to download a limited set of data. Default is true to download all OSM elements
- *  *            "area" : 2000 //optional value to control the area ov the OSM BBox, default is 1000 km²
+ *  *           "area" : 2000 //optional value to control the area ov the OSM BBox, default is 1000 km²
  *              }
  *  *             ,
  *  *  [OPTIONAL ENTRY]  "output" :{ //If not ouput is set the results are keep in the local database
@@ -198,7 +198,7 @@ IProcess workflow() {
                     }
                 }
                 if (inputParameter) {
-                    def osmFilters = inputParameter.get("osm")
+                    def osmFilters = inputParameter.get("location")
                     def downloadAllOSMData = inputParameter.get("all")
                     if(!downloadAllOSMData){
                         downloadAllOSMData = true
@@ -216,6 +216,26 @@ IProcess workflow() {
                         error "The area of the bounding box to be extracted from OSM must be greater than 0 km²"
                         return null
                     }
+
+                    def  overpass_timeout = inputParameter.get("timeout")
+                    if(!overpass_timeout){
+                        overpass_timeout = 900
+                    }
+                    else if(overpass_timeout<=180){
+                        error "The timeout value must be greater than the default value : 180 s"
+                        return null
+                    }
+
+                    def  overpass_maxsize = inputParameter.get("maxsize")
+
+                    if(!overpass_maxsize){
+                        overpass_maxsize = 1073741824
+                    }
+                    else if(overpass_maxsize<=536870912){
+                        error "The maxsize value must be greater than the default value :  536870912 (512 MB)"
+                        return null
+                    }
+
 
                     def deleteOSMFile = inputParameter.get("delete")
                     if(!deleteOSMFile){
@@ -306,7 +326,8 @@ IProcess workflow() {
                                         processing_parameters: processing_parameters,
                                         id_zones: osmFilters, outputFolder: file_outputFolder, ouputTableFiles: outputFolderProperties.tables,
                                         output_datasource: output_datasource, outputTableNames: finalOutputTables, outputSRID :outputSRID, downloadAllOSMData:downloadAllOSMData, deleteOutputData: deleteOutputData,
-                                        deleteOSMFile:deleteOSMFile, logTableZones:logTableZones, bbox_size : osm_size_area)) {
+                                        deleteOSMFile:deleteOSMFile, logTableZones:logTableZones, bbox_size : osm_size_area,
+                                        overpass_timeout :overpass_timeout, overpass_maxsize:overpass_maxsize)) {
                                     h2gis_datasource.getSpatialTable(logTableZones).save("${databaseFolder+File.separator}logzones.geojson")
                                     return null
                                 }
@@ -348,7 +369,8 @@ IProcess workflow() {
                                             processing_parameters: processing_parameters,
                                             id_zones: osmFilters, outputFolder: file_outputFolder, ouputTableFiles: outputFolderProperties.tables,
                                             output_datasource: null, outputTableNames: null, outputSRID :outputSRID, downloadAllOSMData:downloadAllOSMData, deleteOutputData: deleteOutputData,
-                                            deleteOSMFile:deleteOSMFile, logTableZones: logTableZones, bbox_size : osm_size_area)) {
+                                            deleteOSMFile:deleteOSMFile, logTableZones: logTableZones, bbox_size : osm_size_area,
+                                            overpass_timeout :overpass_timeout, overpass_maxsize:overpass_maxsize)) {
                                         h2gis_datasource.getSpatialTable(logTableZones).save("${databaseFolder+File.separator}logzones.geojson")
                                         return null
                                     }
@@ -402,7 +424,9 @@ IProcess workflow() {
                                             processing_parameters: processing_parameters,
                                             id_zones: osmFilters, outputFolder: null, ouputTableFiles: null,
                                             output_datasource: output_datasource, outputTableNames: finalOutputTables,outputSRID :outputSRID,downloadAllOSMData:downloadAllOSMData,
-                                            deleteOutputData: deleteOutputData,deleteOSMFile:deleteOSMFile,logTableZones: logTableZones, bbox_size : osm_size_area)) {
+                                            deleteOutputData: deleteOutputData,deleteOSMFile:deleteOSMFile,
+                                            logTableZones: logTableZones, bbox_size : osm_size_area,
+                                            overpass_timeout :overpass_timeout, overpass_maxsize:overpass_maxsize)) {
                                         h2gis_datasource.getSpatialTable(logTableZones).save("${databaseFolder+File.separator}logzones.geojson")
                                         return null
                                     }
@@ -471,10 +495,11 @@ IProcess osm_processing() {
         id "osm_processing"
         inputs h2gis_datasource: JdbcDataSource, processing_parameters: Map, id_zones: Map,
                 outputFolder: "", ouputTableFiles: "", output_datasource: "", outputTableNames: "", outputSRID : Integer, downloadAllOSMData : true,
-                deleteOutputData:true, deleteOSMFile:false, logTableZones:String, bbox_size : 1000
+                deleteOutputData:true, deleteOSMFile:false, logTableZones:String, bbox_size : 1000,
+                overpass_timeout :180, overpass_maxsize:536870912
         outputs outputTableNames: Map
         run { H2GIS h2gis_datasource, processing_parameters, id_zones, outputFolder, ouputTableFiles, output_datasource, outputTableNames,
-              outputSRID, downloadAllOSMData,deleteOutputData, deleteOSMFile,logTableZones, bbox_size ->
+              outputSRID, downloadAllOSMData,deleteOutputData, deleteOSMFile,logTableZones, bbox_size, overpass_timeout, overpass_maxsize ->
             //Store the zone identifier and the names of the tables
             def outputTableNamesResult = [:]
             //Create the table to log on the processed zone
@@ -505,7 +530,7 @@ IProcess osm_processing() {
                     }
                     //Prepare OSM extraction
                     //TODO set key values ?
-                    def query = "[maxsize:1073741824]" + Utilities.buildOSMQuery(zoneTableNames.envelope, null, OSMElement.NODE, OSMElement.WAY, OSMElement.RELATION)
+                    def query = "[timeout:$overpass_timeout][maxsize:$overpass_maxsize]" + Utilities.buildOSMQuery(zoneTableNames.envelope, null, OSMElement.NODE, OSMElement.WAY, OSMElement.RELATION)
 
                     if(downloadAllOSMData){
                         //Create a custom OSM query to download all requiered data. It will take more time and resources
@@ -515,7 +540,7 @@ IProcess osm_processing() {
                                            "landuse", "landcover",
                                            "vegetation","waterway"]
                         //TODO : Remove unnecessary keys according the output tables set in the config file
-                        query =  "[maxsize:1073741824]"+ Utilities.buildOSMQueryWithAllData(zoneTableNames.envelope, keysValues, OSMElement.NODE, OSMElement.WAY, OSMElement.RELATION)
+                        query =  "[timeout:$overpass_timeout][maxsize:$overpass_maxsize]"+ Utilities.buildOSMQueryWithAllData(zoneTableNames.envelope, keysValues, OSMElement.NODE, OSMElement.WAY, OSMElement.RELATION)
                     }
 
                     def extract = OSMTools.Loader.extract()

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -50,7 +50,7 @@ import org.orbisgis.geoclimate.Geoindicators
  *  *         "delete" :false
  *  *     },
  *  * [REQUIRED]   "input" : {
- *  *            "location" : ["filter"] // OSM filter to extract the data. Can be a place name supported by nominatim
+ *  *            "locations" : ["filter"] // OSM filter to extract the data. Can be a place name supported by nominatim
  *                                  // e.g "osm" : ["oran", "plourivo"]
  *                                  // or bbox expressed as "osm" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]
  *  *           "all":true //optional value if the user wants to download a limited set of data. Default is true to download all OSM elements
@@ -198,7 +198,7 @@ IProcess workflow() {
                     }
                 }
                 if (inputParameter) {
-                    def osmFilters = inputParameter.get("location")
+                    def osmFilters = inputParameter.get("locations")
                     def downloadAllOSMData = inputParameter.get("all")
                     if(!downloadAllOSMData){
                         downloadAllOSMData = true

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -208,7 +208,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "database" :
                                 ["user" : "sa",
@@ -248,7 +248,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "database" :
                                 ["user" : "orbisgis",
@@ -312,7 +312,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory,
                         "srid":4326],
@@ -353,7 +353,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory],
                 "parameters":
@@ -381,7 +381,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
+                        "location" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
                 "output" :[
                         "folder" : directory]
         ]
@@ -403,7 +403,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
+                        "location" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
                 "output" :[
                         "folder" : directory]
         ]
@@ -425,7 +425,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["", [-3.0961382389068604, -3.1055688858032227,48.77155634881654,]]],
+                        "location" : ["", [-3.0961382389068604, -3.1055688858032227,48.77155634881654,]]],
                 "output" :[
                         "folder" : directory]
         ]
@@ -447,7 +447,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory],
                 "parameters":
@@ -487,7 +487,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory],
                 "parameters":
@@ -515,7 +515,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : ["path": directory,
                                     "tables": ["building"]]],
@@ -547,7 +547,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                 "folder" : ["path": directory,
                     "tables": ["grid_indicators", "zones"]]],
@@ -584,7 +584,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : ["path": directory,
                                     "tables": ["grid_indicators", "zones", "rsu_lcz"]]],
@@ -618,7 +618,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : [[48.49749,5.25349,48.58082,5.33682]],
+                        "location" : [[48.49749,5.25349,48.58082,5.33682]],
                         "delete":true],
                 "output" :[
                         "folder" : ["path": directory,
@@ -653,7 +653,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Rennes"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" :directory]
                 ,
@@ -693,7 +693,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : [[
+                        "location" : [[
                                          53.83061, 9.83664, 53.91394, 9.91997
                                  ]]],
                 "output" :["folder" : directory,srid: 4326]
@@ -735,7 +735,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory],
                 "parameters":
@@ -766,7 +766,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"]],
+                        "location" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : ["path": directory,
                                     "tables": ["road_traffic"]]],
@@ -795,7 +795,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["Pont-de-Veyle"],
+                        "location" : ["Pont-de-Veyle"],
                         "area" : -1],
                 "output" :[
                         "database" :

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -208,7 +208,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "database" :
                                 ["user" : "sa",
@@ -248,7 +248,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "database" :
                                 ["user" : "orbisgis",
@@ -312,7 +312,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory,
                         "srid":4326],
@@ -353,7 +353,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory],
                 "parameters":
@@ -381,7 +381,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "location" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
+                        "locations" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
                 "output" :[
                         "folder" : directory]
         ]
@@ -403,7 +403,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "location" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
+                        "locations" : [[38.89557963573336,-77.03930318355559,38.89944983078282,-77.03364372253417]]],
                 "output" :[
                         "folder" : directory]
         ]
@@ -425,7 +425,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "location" : ["", [-3.0961382389068604, -3.1055688858032227,48.77155634881654,]]],
+                        "locations" : ["", [-3.0961382389068604, -3.1055688858032227,48.77155634881654,]]],
                 "output" :[
                         "folder" : directory]
         ]
@@ -447,7 +447,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory],
                 "parameters":
@@ -487,7 +487,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory],
                 "parameters":
@@ -515,7 +515,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : ["path": directory,
                                     "tables": ["building"]]],
@@ -547,7 +547,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                 "folder" : ["path": directory,
                     "tables": ["grid_indicators", "zones"]]],
@@ -584,7 +584,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : ["path": directory,
                                     "tables": ["grid_indicators", "zones", "rsu_lcz"]]],
@@ -618,7 +618,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : [[48.49749,5.25349,48.58082,5.33682]],
+                        "locations" : [[48.49749,5.25349,48.58082,5.33682]],
                         "delete":true],
                 "output" :[
                         "folder" : ["path": directory,
@@ -653,7 +653,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" :directory]
                 ,
@@ -693,7 +693,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : [[
+                        "locations" : [[
                                          53.83061, 9.83664, 53.91394, 9.91997
                                  ]]],
                 "output" :["folder" : directory,srid: 4326]
@@ -735,7 +735,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :true
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : directory],
                 "parameters":
@@ -766,7 +766,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"]],
+                        "locations" : ["Pont-de-Veyle"]],
                 "output" :[
                         "folder" : ["path": directory,
                                     "tables": ["road_traffic"]]],
@@ -795,7 +795,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         "delete" :false
                 ],
                 "input" : [
-                        "location" : ["Pont-de-Veyle"],
+                        "locations" : ["Pont-de-Veyle"],
                         "area" : -1],
                 "output" :[
                         "database" :


### PR DESCRIPTION
As discussed with @simogeo and @j3r3m1 this PR introduces some changes in the input parameters.
 - osm and bdtopo_v2 identifiers have been remove 
 - timeout and maxsize properties can be set to overpass query

Example 
```
"input" : [
                        "locations" : ["Pont-de-Veyle"],
                        "timeout" : 900,
                        "maxsize":1073741824
]
```
default timeout and  maxsize are aligned with Overpass API (180 s and 512 Mb)