### PR TITLE
Store the geoclimate version and build number in zone table

### DIFF
--- a/geoclimate/src/main/groovy/org/orbisgis/geoclimate/Geoclimate.groovy
+++ b/geoclimate/src/main/groovy/org/orbisgis/geoclimate/Geoclimate.groovy
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable
  */
 @CommandLine.Command(name = "Geoclimate",
         sortOptions = false,
-        version = "0.1",
+        version = "0.0.2",
         mixinStandardHelpOptions = true,
         description = "Simple command line tool to run Geoclimate algorithms",
         header =

--- a/geoindicators/pom.xml
+++ b/geoindicators/pom.xml
@@ -150,6 +150,23 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
         </plugins>
+
+        <resources>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/geoclimate.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/geoclimate.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
     </build>
 
     <distributionManagement>

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/Geoindicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/Geoindicators.groovy
@@ -27,6 +27,7 @@ abstract class Geoindicators  extends GroovyProcessFactory  {
 
     //The whole chain to run the geoindicators
     public static WorkflowGeoIndicators = new WorkflowGeoIndicators()
+    static Properties GEOCLIMATE_PROPERTIES
 
     //Utility methods
     static def getUuid(){
@@ -111,5 +112,34 @@ abstract class Geoindicators  extends GroovyProcessFactory  {
      */
     static  void clearTablesCache(){
         System.properties.removeAll {it.key.startsWith("GEOCLIMATE")}
+    }
+
+    /**
+     * Return the current GeoClimate version
+     * @return
+     */
+    static def version() {
+        return geoclimate_property("version")
+    }
+
+    /**
+     * Return the current GeoClimate build number
+     * @return
+     */
+    static def buildNumber() {
+        return geoclimate_property("build")
+    }
+
+    /**
+     * Return geoclimate properties
+     * @param name
+     * @return
+     */
+    static def geoclimate_property(String name) {
+        if(!GEOCLIMATE_PROPERTIES) {
+            GEOCLIMATE_PROPERTIES = new Properties()
+            GEOCLIMATE_PROPERTIES.load(Geoindicators.getResourceAsStream("geoclimate.properties"))
+        }
+        return GEOCLIMATE_PROPERTIES.get(name)
     }
 }

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -1806,8 +1806,10 @@ IProcess computeGeoclimateIndicators() {
                 NB_BLOCK INTEGER,
                 NB_RSU INTEGER,
                 COMPUTATION_TIME INTEGER,
-                LAST_UPDATE VARCHAR
+                LAST_UPDATE VARCHAR, VERSION VARCHAR, BUILD_NUMBER VARCHAR
                 )""".toString()
+
+
             //Update reporting to the zone table
             datasource.execute"""update ${zoneTable} 
             set nb_estimated_building = 0, 
@@ -1815,7 +1817,9 @@ IProcess computeGeoclimateIndicators() {
             nb_block =  ${nbBlock},
             nb_rsu = ${nbRSU},
             computation_time = ${(System.currentTimeMillis()-start)/1000},
-            last_update = CAST(now() AS VARCHAR)""".toString()
+            last_update = CAST(now() AS VARCHAR),
+            version = '${Geoindicators.version()}',
+            build_number = '${Geoindicators.buildNumber()}'""".toString()
 
             return [outputTableBuildingIndicators   : buildingIndicators,
                     outputTableBlockIndicators      : blockIndicators,

--- a/geoindicators/src/main/resources/org/orbisgis/geoclimate/geoclimate.properties
+++ b/geoindicators/src/main/resources/org/orbisgis/geoclimate/geoclimate.properties
@@ -1,0 +1,2 @@
+version=${project.version}
+build=${buildNumber}

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicatorsTest.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicatorsTest.groovy
@@ -479,4 +479,10 @@ class WorkflowGeoIndicatorsTest {
         }
     }
 
+    @Test
+    void GeoClimateProperties() {
+        assert "0.0.2-SNAPSHOT" ==  Geoindicators.version()
+        assertNotNull Geoindicators.buildNumber()
+    }
+
 }


### PR DESCRIPTION
This PR adds two new columns on the zone table : the geoclimate version and the build number.
