### PR TITLE
Updated 'lcz_primary' and 'lcz_secondary' style files

### DIFF
--- a/geoindicators/src/main/resources/styles/lcz_primary.sld
+++ b/geoindicators/src/main/resources/styles/lcz_primary.sld
@@ -246,15 +246,9 @@
         <sld:Rule>
           <sld:Name>Undefined</sld:Name>
           <ogc:Filter>
-            <ogc:Or>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>LCZ_PRIMARY</ogc:PropertyName>
-                <ogc:Literal/>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsNull>
-                <ogc:PropertyName>lcz1</ogc:PropertyName>
-              </ogc:PropertyIsNull>
-            </ogc:Or>
+            <ogc:PropertyIsNull>
+              <ogc:PropertyName>LCZ_PRIMARY</ogc:PropertyName>
+            </ogc:PropertyIsNull>
           </ogc:Filter>
           <sld:PolygonSymbolizer>
             <sld:Fill>

--- a/geoindicators/src/main/resources/styles/lcz_secondary.sld
+++ b/geoindicators/src/main/resources/styles/lcz_secondary.sld
@@ -246,15 +246,9 @@
         <sld:Rule>
           <sld:Name>Undefined</sld:Name>
           <ogc:Filter>
-            <ogc:Or>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>LCZ_SECONDARY</ogc:PropertyName>
-                <ogc:Literal/>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsNull>
-                <ogc:PropertyName>LCZ_SECONDARY</ogc:PropertyName>
-              </ogc:PropertyIsNull>
-            </ogc:Or>
+            <ogc:PropertyIsNull>
+              <ogc:PropertyName>LCZ_SECONDARY</ogc:PropertyName>
+            </ogc:PropertyIsNull>
           </ogc:Filter>
           <sld:PolygonSymbolizer>
             <sld:Fill>


### PR DESCRIPTION
Correction a small inconsistency in the definition of the style to be applied for the primary and secondary lcz (see picture)

(It might also be interesting to reference these files in the wiki so that Geoclimate users can download them directly).

![image](https://user-images.githubusercontent.com/93529214/159702671-12be1bb0-7ccd-45f4-b4da-6b0680df82db.png)
