### PR TITLE
Change OSM column names formatting

### DIFF
--- a/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
@@ -1118,7 +1118,7 @@ def findIDZones(JdbcDataSource h2gis_datasource, def id_zones, def srid){
                 }
             }
             if(id_zones_tmp){
-                def zones =id_zones_tmp.join(",")
+                def zones =id_zones_tmp.join("','")
                 h2gis_datasource.withBatch(100, "INSERT INTO COMMUNE VALUES(?,?)") { ps ->
                     h2gis_datasource.eachRow("""select THE_GEOM, CODE_INSEE FROM COMMUNE_TMP where code_insee in 
                     ('${zones}') OR nom in('${zones}')"""){ row ->

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
@@ -523,7 +523,7 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest{
                 ],
                 "input" :[
                         "folder": ["path" :dataFolder,
-                                   "locations":[communeToTest]]],
+                                   "locations":[communeToTest,communeToTest]]],
                 "output" :[
                         "folder" : ["path": "$directory",
                                     "tables": ["grid_indicators"]]],

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
@@ -490,13 +490,13 @@ IProcess formatHydroLayer() {
                         query = "select id , CASE WHEN st_overlaps(st_makevalid(a.the_geom), b.the_geom) " +
                                 "THEN st_force2D(st_intersection(st_makevalid(a.the_geom), st_makevalid(b.the_geom))) " +
                                 "ELSE st_force2D(st_makevalid(a.the_geom)) " +
-                                "END AS the_geom , a.\"NATURAL\", a.layer" +
+                                "END AS the_geom , a.\"natural\", a.\"layer\"" +
                                 " FROM " +
                                 "$inputTableName AS a, $inputZoneEnvelopeTableName AS b " +
                                 "WHERE " +
                                 "a.the_geom && b.the_geom "
                     } else {
-                        query = "select id,  st_force2D(st_makevalid(the_geom)) as the_geom, \"NATURAL\", layer FROM $inputTableName "
+                        query = "select id,  st_force2D(st_makevalid(the_geom)) as the_geom, \"natural\", \"layer\" FROM $inputTableName "
 
                     }
                     int rowcount = 1
@@ -619,7 +619,7 @@ static String[] getTypeAndUse(def row, def columnNames, def myMap) {
             use = type
         }
         finalVal.value.each { osmVals ->
-            if (columnNames.contains(osmVals.key.toUpperCase())) {
+            if (columnNames.contains(osmVals.key)) {
                 def columnValue = row.getString(osmVals.key)
                 if (columnValue != null) {
                     osmVals.value.each { osmVal ->
@@ -833,7 +833,7 @@ static String getTypeValue(def row, def columnNames, def myMap) {
     myMap.each { finalVal ->
         def finalKey = finalVal.key
         finalVal.value.each { osmVals ->
-            if (columnNames.contains(osmVals.key.toUpperCase())) {
+            if (columnNames.contains(osmVals.key)) {
                 def columnValue = row.getString(osmVals.key)
                 if (columnValue != null) {
                     osmVals.value.each { osmVal ->

--- a/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/Transform.groovy
+++ b/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/Transform.groovy
@@ -178,6 +178,15 @@ def extractWaysAsPolygons () {
             def columnsSelector = getColumnSelector(osmTableTag, tags, columnsToKeep)
             def tagsFilter = createWhereFilter(tags)
 
+            if(!datasource.hasTable(osmTableTag)){
+                debug "No tags table found to build the table. An empty table will be returned."
+                datasource """ 
+                    DROP TABLE IF EXISTS $outputTableName;
+                    CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                """.toString()
+                return [outputTableName: outputTableName]
+            }
+
             if (datasource.firstRow(countTagsQuery.toString()).count <= 0) {
                 debug "No keys or values found to extract ways. An empty table will be returned."
                 datasource """ 
@@ -300,6 +309,15 @@ def extractRelationsAsPolygons () {
             def countTagsQuery = getCountTagsQuery(osmTableTag, tags)
             def columnsSelector = getColumnSelector(osmTableTag, tags, columnsToKeep)
             def tagsFilter = createWhereFilter(tags)
+
+            if(!datasource.hasTable(osmTableTag)){
+                debug "No tags table found to build the table. An empty table will be returned."
+                datasource """ 
+                    DROP TABLE IF EXISTS $outputTableName;
+                    CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                """.toString()
+                return [outputTableName: outputTableName]
+            }
 
             if (datasource.firstRow(countTagsQuery.toString()).count <= 0) {
                 debug "No keys or values found in the relations. An empty table will be returned."
@@ -502,6 +520,15 @@ def extractWaysAsLines () {
             def columnsSelector = getColumnSelector(osmTableTag, tags, columnsToKeep)
             def tagsFilter = createWhereFilter(tags)
 
+            if(!datasource.hasTable(osmTableTag)){
+                debug "No tags table found to build the table. An empty table will be returned."
+                datasource """ 
+                    DROP TABLE IF EXISTS $outputTableName;
+                    CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                """.toString()
+                return [outputTableName: outputTableName]
+            }
+
             if (datasource.firstRow(countTagsQuery.toString()).count <= 0) {
                 debug "No keys or values found in the ways. An empty table will be returned."
                 datasource """ 
@@ -609,8 +636,16 @@ def extractRelationsAsLines() {
             def outputTableName = postfix "RELATIONS_LINES"
             def osmTableTag = prefix osmTablesPrefix, "relation_tag"
             def countTagsQuery = getCountTagsQuery(osmTableTag, tags)
-            def columnsSelector = getColumnSelector(osmTableTag, tags, columnsToKeep)
             def tagsFilter = createWhereFilter(tags)
+
+            if(!datasource.hasTable(osmTableTag)){
+                debug "No tags table found to build the table. An empty table will be returned."
+                datasource """ 
+                    DROP TABLE IF EXISTS $outputTableName;
+                    CREATE TABLE $outputTableName (the_geom GEOMETRY(GEOMETRY,$epsgCode));
+                """.toString()
+                return [outputTableName: outputTableName]
+            }
 
             if (datasource.firstRow(countTagsQuery.toString()).count <= 0) {
                 warn "No keys or values found in the relations. An empty table will be returned."
@@ -678,6 +713,7 @@ def extractRelationsAsLines() {
                 CREATE INDEX ON $relationsLinesTmp(id_relation);
         """.toString()
 
+            def columnsSelector = getColumnSelector(osmTableTag, tags, columnsToKeep)
             datasource """
                 DROP TABLE IF EXISTS $outputTableName;
                 CREATE TABLE $outputTableName AS

--- a/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/TransformUtils.groovy
+++ b/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/TransformUtils.groovy
@@ -433,7 +433,7 @@ class TransformUtils {
         def list = []
         rowskeys.tag_key.each { it ->
             if(it != null)
-                list << "MAX(CASE WHEN b.tag_key = '$it' THEN b.tag_value END) AS \"${it.toUpperCase()}\""
+                list << "MAX(CASE WHEN b.tag_key = '$it' THEN b.tag_value END) AS \"${it}\""
         }
         def tagList =""
         if (!list.isEmpty()) {

--- a/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/TransformTest.groovy
+++ b/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/TransformTest.groovy
@@ -325,12 +325,12 @@ class TransformTest extends AbstractOSMTest {
         assertTrue extractWaysAsPolygons.results.isEmpty()
 
         LOGGER.warn("An error will be thrown next")
-        assertFalse extractWaysAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
-        assertTrue extractWaysAsPolygons.results.isEmpty()
+        assertTrue extractWaysAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
+        assertFalse extractWaysAsPolygons.results.isEmpty()
 
         LOGGER.warn("An error will be thrown next")
-        assertFalse extractWaysAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:null, columnsToKeep:null)
-        assertTrue extractWaysAsPolygons.results.isEmpty()
+        assertTrue extractWaysAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:null, columnsToKeep:null)
+        assertFalse extractWaysAsPolygons.results.isEmpty()
     }
 
     /**
@@ -412,12 +412,12 @@ class TransformTest extends AbstractOSMTest {
         assertTrue extractRelationsAsPolygons.results.isEmpty()
 
         LOGGER.warn("An error will be thrown next")
-        assertFalse extractRelationsAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
-        assertTrue extractRelationsAsPolygons.results.isEmpty()
+        assertTrue extractRelationsAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
+        assertFalse extractRelationsAsPolygons.results.isEmpty()
 
         LOGGER.warn("An error will be thrown next")
-        assertFalse extractRelationsAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:null, columnsToKeep:null)
-        assertTrue extractRelationsAsPolygons.results.isEmpty()
+        assertTrue extractRelationsAsPolygons(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:null, columnsToKeep:null)
+        assertFalse extractRelationsAsPolygons.results.isEmpty()
     }
 
     /**
@@ -499,12 +499,12 @@ class TransformTest extends AbstractOSMTest {
         assertTrue extractWaysAsLines.results.isEmpty()
 
         LOGGER.warn("An error will be thrown next")
-        assertFalse extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
-        assertTrue extractWaysAsLines.results.isEmpty()
+        assertTrue extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
+        assertFalse extractWaysAsLines.results.isEmpty()
 
         LOGGER.warn("An error will be thrown next")
-        assertFalse extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:null, columnsToKeep:null)
-        assertTrue extractWaysAsLines.results.isEmpty()
+        assertTrue extractWaysAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:null, columnsToKeep:null)
+        assertFalse extractWaysAsLines.results.isEmpty()
     }
 
     /**
@@ -587,12 +587,12 @@ class TransformTest extends AbstractOSMTest {
         assertTrue extractRelationsAsLines.results.isEmpty()
 
         LOGGER.warn("An error will be thrown next")
-        assertFalse extractRelationsAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
-        assertTrue extractRelationsAsLines.results.isEmpty()
+        assertTrue extractRelationsAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:tags, columnsToKeep:columnsToKeep)
+        assertFalse extractRelationsAsLines.results.isEmpty()
 
         LOGGER.warn("An error will be thrown next")
-        assertFalse extractRelationsAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:null, columnsToKeep:null)
-        assertTrue extractRelationsAsLines.results.isEmpty()
+        assertTrue extractRelationsAsLines(datasource: ds, osmTablesPrefix: prefix, epsgCode:epsgCode, tags:null, columnsToKeep:null)
+        assertFalse extractRelationsAsLines.results.isEmpty()
     }
 
     /**
@@ -700,7 +700,7 @@ class TransformTest extends AbstractOSMTest {
         transform.execute(datasource: h2GIS, osmTablesPrefix: prefix, tags: tags)
         outputTableName = transform.results.outputTableName
         assertEquals 131, h2GIS.firstRow("select count(*) as count from ${outputTableName}").count as int
-        assertEquals 123, h2GIS.firstRow("select count(*) as count from ${outputTableName} where landuse='grass'").count as int
+        assertEquals 123, h2GIS.firstRow("select count(*) as count from ${outputTableName} where \"landuse\"='grass'").count as int
 
     }
 

--- a/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/utils/TransformUtilsTest.groovy
+++ b/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/utils/TransformUtilsTest.groovy
@@ -237,19 +237,19 @@ class TransformUtilsTest extends AbstractOSMTest {
 
         h2gis.execute("CREATE TABLE toto (id int, tag_key varchar, tag_value VARCHAR array[255])")
         h2gis.execute("INSERT INTO toto VALUES (0, 'material', ('concrete', 'brick'))")
-        assertGStringEquals ", MAX(CASE WHEN b.tag_key = 'material' THEN b.tag_value END) AS \"MATERIAL\"",
-                TransformUtils.createTagList(h2gis, "SELECT tag_key FROM $osmTable")
+        assertEquals(", MAX(CASE WHEN b.tag_key = 'material' THEN b.tag_value END) AS \"material\"",
+                TransformUtils.createTagList(h2gis, "SELECT tag_key FROM $osmTable").toString())
         h2gis.execute("DROP TABLE IF EXISTS toto")
 
         h2gis.execute("CREATE TABLE toto (id int, tag_key varchar, tag_value VARCHAR array[255])")
         h2gis.execute("INSERT INTO toto VALUES (1, 'water', null)")
-        assertGStringEquals ", MAX(CASE WHEN b.tag_key = 'water' THEN b.tag_value END) AS \"WATER\"",
+        assertGStringEquals ", MAX(CASE WHEN b.tag_key = 'water' THEN b.tag_value END) AS \"water\"",
                 TransformUtils.createTagList(h2gis, "SELECT tag_key FROM $osmTable")
         h2gis.execute("DROP TABLE IF EXISTS toto")
 
         h2gis.execute("CREATE TABLE toto (id int, tag_key varchar, tag_value VARCHAR array[255])")
         h2gis.execute("INSERT INTO toto VALUES (2, 'road', '{}')")
-        assertGStringEquals ", MAX(CASE WHEN b.tag_key = 'road' THEN b.tag_value END) AS \"ROAD\"",
+        assertGStringEquals ", MAX(CASE WHEN b.tag_key = 'road' THEN b.tag_value END) AS \"road\"",
                 TransformUtils.createTagList(h2gis, "SELECT tag_key FROM $osmTable")
         h2gis.execute("DROP TABLE IF EXISTS toto")
 


### PR DESCRIPTION
This PR changes the OSM column names formatting to keep the original OSM case.
e.g : "BUILDING:LEVEL" replaced by "\"building:level\""
So we can for example reuse some SQL queries provided by the OSM tool ecosystem as geovelo : 
https://gitlab.com/geovelo-public/requetes_amenagements_cyclables/-/blob/master/Bandes_cyclables-1xD.sql

This PR fixes also a bug on BDTopo workflow when the user set multiple location codes.