### PR TITLE
Improve impervious areas definition

### DIFF
--- a/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
+++ b/bdtopo_v2/src/main/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2.groovy
@@ -188,6 +188,18 @@ IProcess workflow() {
             if (geoclimatedb) {
                 def h2gis_folder = geoclimatedb.get("folder")
                 if (h2gis_folder) {
+                    File tmp_folder_db =  new File(h2gis_folder)
+                    if(!tmp_folder_db.exists()){
+                        if(tmp_folder_db.mkdir()){
+                            h2gis_folder = null
+                            error "You don't have permission to write in the folder $h2gis_folder \n" +
+                                    "Please check the folder."
+                            return
+                        }
+                    }else  if (!tmp_folder_db.isDirectory()) {
+                        error "Invalid output folder $h2gis_folder."
+                        return
+                    }
                     databaseFolder = h2gis_folder
                 }
                 databasePath = databaseFolder + File.separator + databaseName
@@ -293,17 +305,17 @@ IProcess workflow() {
                     outputFileTables = outputFiles.tables
                     //Check if we can write in the output folder
                     file_outputFolder = new File(outputFiles.path)
-                    if (!file_outputFolder.isDirectory()) {
-                        error "The directory $file_outputFolder doesn't exist."
+                    if(!file_outputFolder.exists()){
+                        if(file_outputFolder.mkdir()){
+                            file_outputFolder = null
+                            error "You don't have permission to write in the folder $outputFolder \n" +
+                                    "Please check the folder."
+                            return
+                        }
+                    }else  if (!file_outputFolder.isDirectory()) {
+                        error "Invalid output folder $file_outputFolder."
                         return
                     }
-                    if (!file_outputFolder.canWrite()) {
-                        file_outputFolder = null
-                        error "You don't have permission to write in the folder $outputFolder \n" +
-                                "Please check the folder."
-                        return
-                    }
-
                 }
                 if (outputDataBase) {
                     //Check the conditions to store the results a database

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/InputDataFormattingTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/InputDataFormattingTest.groovy
@@ -60,7 +60,7 @@ class InputDataFormattingTest {
         assertTrue processFormatting.execute([datasource: h2GISDatabase,
                                               inputTableName: resultsImport.outputBuildingName,
                                               inputZoneEnvelopeTableName: resultsImport.outputZoneName,
-                                              inputImpervious: resultsImport.outputImperviousName])
+                                              inputUrbanAreas: resultsImport.outputUrbanAreas])
         def tableOutput = processFormatting.results.outputTableName
         assertTrue(h2GISDatabase.firstRow("""SELECT count(*) as count from $tableOutput where TYPE is not null;""".toString()).count>0)
         assertTrue(h2GISDatabase.firstRow("""SELECT count(*) as count from $tableOutput where MAIN_USE is not null;""".toString()).count>0)

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/InputDataLoadingTest.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/InputDataLoadingTest.groovy
@@ -192,7 +192,7 @@ class InputDataLoadingTest {
         table = h2GISDatabase.getTable(tableName)
         assertNotNull(table)
         assertEquals(4, table.columnCount)
-        assertEquals(13, table.rowCount)
+        assertEquals(16, table.rowCount)
         // Check if the column types are correct
         assertTrue(table.THE_GEOM.spatial)
         assertEquals('CHARACTER VARYING', table.columnType('ID_SOURCE'))
@@ -559,7 +559,7 @@ class InputDataLoadingTest {
         def table = h2GISDatabase.getTable(tableName)
         assertNotNull(table)
         assertEquals(4, table.columnCount)
-        assertEquals(2, table.rowCount)
+        assertEquals(5, table.rowCount)
         // Check if the column types are correct
         assertTrue(table.THE_GEOM.spatial)
         assertEquals('CHARACTER VARYING', table.columnType('ID_SOURCE'))
@@ -574,7 +574,7 @@ class InputDataLoadingTest {
         // Check if the SURFACE_ACTIVITE table has the correct number of columns and rows
         table = h2GISDatabase.getTable("SURFACE_ACTIVITE")
         assertNotNull(table)
-        assertEquals(3, table.columnCount)
+        assertEquals(4, table.columnCount)
         assertEquals(0, table.rowCount)
         // Check if the column types are correct
         assertTrue(table.THE_GEOM.spatial)
@@ -655,7 +655,7 @@ class InputDataLoadingTest {
         def table = h2GISDatabase.getTable(tableName)
         assertNotNull(table)
         assertEquals(4, table.columnCount)
-        assertEquals(13, table.rowCount)
+        assertEquals(16, table.rowCount)
         // Check if the column types are correct
         assertTrue(table.THE_GEOM.spatial)
         assertEquals('CHARACTER VARYING', table.columnType('ID_SOURCE'))
@@ -703,7 +703,7 @@ class InputDataLoadingTest {
         def table = h2GISDatabase.getTable(tableName)
         assertNotNull(table)
         assertEquals(4, table.columnCount)
-        assertEquals(11, table.rowCount)
+        assertEquals(14, table.rowCount)
         // Check if the column types are correct
         assertTrue(table.the_geom.isSpatial())
         assertEquals('CHARACTER VARYING', table.columnType('ID_SOURCE'))

--- a/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
+++ b/bdtopo_v2/src/test/groovy/org/orbisgis/geoclimate/bdtopo_v2/WorkflowBDTopo_V2Test.groovy
@@ -901,6 +901,13 @@ class WorkflowBDTopo_V2Test extends WorkflowAbstractTest {
         assertFalse(process.execute(input: createConfigFile(bdTopoParameters, directory)))
     }
 
+    @Disabled
+    @Test
+    void runFromFile() {
+        IProcess process = BDTopo_V2.WorkflowBDTopo_V2.workflow()
+        assertTrue(process.execute(input:'/home/ebocher/Téléchargements/formation_geoclimate/bdtopo_demo_test.json'))
+    }
+
 
     /**
      * Check if the table exist and contains at least one row

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GenericIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GenericIndicators.groovy
@@ -515,8 +515,8 @@ IProcess distributionCharacterization() {
                         queryCreateTable = "${queryCreateTable[0..-2]}, $EXTREMUM_VAL DOUBLE PRECISION)"
                     }
                     datasource queryCreateTable.toString()
-                    // Will insert values by batch of 1000 in the table
-                    datasource.withBatch(1000) { stmt ->
+                    // Will insert values by batch of 100 in the table
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow("SELECT * FROM $distribTableNameNoNull".toString()) { row ->
                             def rowMap = row.toRowResult()
                             def id_rsu = rowMap."$inputId"
@@ -555,8 +555,8 @@ IProcess distributionCharacterization() {
                     }
 
                     datasource queryCreateTable.toString()
-                    // Will insert values by batch of 1000 in the table
-                    datasource.withBatch(1000) { stmt ->
+                    // Will insert values by batch of 100 in the table
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow("SELECT * FROM $distribTableNameNoNull".toString()) { row ->
                             def rowMap = row.toRowResult()
                             def id_rsu = rowMap."$inputId"
@@ -596,8 +596,8 @@ IProcess distributionCharacterization() {
 
                     datasource queryCreateTable.toString()
 
-                    // Will insert values by batch of 1000 in the table
-                    datasource.withBatch(1000) { stmt ->
+                    // Will insert values by batch of 100 in the table
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow("SELECT * FROM $distribTableNameNoNull".toString()) { row ->
                             def rowMap = row.toRowResult()
                             def id_rsu = rowMap."$inputId"

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/RoadIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/RoadIndicators.groovy
@@ -115,7 +115,7 @@ IProcess build_road_traffic() {
                     } else {
                         queryMapper += "${flatListColumns}, st_force2D(a.the_geom) as the_geom FROM $inputTableName  as a"
                     }
-                    datasource.withBatch(1000) { stmt ->
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow(queryMapper) { row ->
                             //Find road type
                             def source_road_type = row."type"

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -2332,7 +2332,7 @@ IProcess formatEstimatedBuilding() {
                     def columnNames = inputSpatialTable.columns
                     queryMapper += " ${columnNames.join(",")} FROM $inputTableName"
 
-                    datasource.withBatch(1000) { stmt ->
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow(queryMapper) { row ->
                             def heightRoof = row.height_roof
                             def heightWall = heightRoof

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
@@ -225,7 +225,7 @@ IProcess formatRoadLayer() {
                     }
                     int rowcount = 1
                     def speedPattern = Pattern.compile("([0-9]+)( ([a-zA-Z]+))?", Pattern.CASE_INSENSITIVE)
-                    datasource.withBatch(1000) { stmt ->
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow(queryMapper) { row ->
                             def processRow = true
                             def road_access = row.'access'
@@ -348,7 +348,7 @@ IProcess formatRailsLayer() {
 
                     }
                     int rowcount = 1
-                    datasource.withBatch(1000) { stmt ->
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow(queryMapper) { row ->
                             def type = getTypeValue(row, columnNames, mappingType)
                             def zIndex = getZIndex(row.'layer')
@@ -567,7 +567,7 @@ IProcess formatImperviousLayer() {
                         queryMapper += ", st_force2D(a.the_geom) as the_geom FROM $inputTableName  as a"
                     }
                     int rowcount = 1
-                    datasource.withBatch(1000) { stmt ->
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow(queryMapper) { row ->
                             def toAdd = true
                             if ((row.surface != null) && (row.surface == "grass")) {
@@ -976,7 +976,7 @@ IProcess formatUrbanAreas() {
 
                     }
                     int rowcount = 1
-                    datasource.withBatch(1000) { stmt ->
+                    datasource.withBatch(100) { stmt ->
                         datasource.eachRow(queryMapper) { row ->
                             def typeAndUseValues = getTypeAndUse(row, columnNames, mappingType)
                             def use = typeAndUseValues[1]

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -171,6 +171,18 @@ IProcess workflow() {
             if (geoclimatedb) {
                 def h2gis_folder = geoclimatedb.get("folder")
                 if (h2gis_folder) {
+                    File tmp_folder_db =  new File(h2gis_folder)
+                    if(!tmp_folder_db.exists()){
+                        if(tmp_folder_db.mkdir()){
+                            h2gis_folder = null
+                            error "You don't have permission to write in the folder $h2gis_folder \n" +
+                                    "Please check the folder."
+                            return
+                        }
+                    }else  if (!tmp_folder_db.isDirectory()) {
+                        error "Invalid output folder $h2gis_folder."
+                        return
+                    }
                     databaseFolder = h2gis_folder
                 }
                 databasePath = databaseFolder + File.separator + databaseName
@@ -310,14 +322,15 @@ IProcess workflow() {
                     outputFileTables = outputFiles.tables
                     //Check if we can write in the output folder
                     file_outputFolder = new File(outputFiles.path)
-                    if (!file_outputFolder.isDirectory()) {
-                        error "The directory $file_outputFolder doesn't exist."
-                        return
-                    }
-                    if (!file_outputFolder.canWrite()) {
-                        file_outputFolder = null
-                        error "You don't have permission to write in the folder $outputFolder \n" +
-                                "Please check the folder."
+                    if(!file_outputFolder.exists()){
+                        if(file_outputFolder.mkdir()){
+                            file_outputFolder = null
+                            error "You don't have permission to write in the folder $outputFolder \n" +
+                                    "Please check the folder."
+                            return
+                        }
+                    }else  if (!file_outputFolder.isDirectory()) {
+                        error "Invalid output folder $file_outputFolder."
                         return
                     }
                 }

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -173,7 +173,7 @@ IProcess workflow() {
                 if (h2gis_folder) {
                     File tmp_folder_db =  new File(h2gis_folder)
                     if(!tmp_folder_db.exists()){
-                        if(tmp_folder_db.mkdir()){
+                        if(!tmp_folder_db.mkdir()){
                             h2gis_folder = null
                             error "You don't have permission to write in the folder $h2gis_folder \n" +
                                     "Please check the folder."
@@ -1114,7 +1114,7 @@ def abstractModelTableBatchExportTable(JdbcDataSource output_datasource, def out
                 output_datasource.execute("DELETE FROM $output_table WHERE id_zone= '$id_zone'".toString())
                 //If the table exists we populate it with the last result
                 info "Start to export the table $h2gis_table_to_save into the table $output_table for the zone $id_zone"
-                int BATCH_MAX_SIZE = 1000
+                int BATCH_MAX_SIZE = 100
                 ITable inputRes = prepareTableOutput(h2gis_table_to_save, filter, inputSRID, h2gis_datasource, output_table, outputSRID, output_datasource)
                 if (inputRes) {
                     def outputColumns = output_datasource.getTable(output_table).getColumnsTypes()
@@ -1234,7 +1234,7 @@ def indicatorTableBatchExportTable(def output_datasource, def output_table, def 
                     output_datasource.execute("DELETE FROM $output_table WHERE id_zone='$id_zone'".toString())
                     //If the table exists we populate it with the last result
                     info "Start to export the table $h2gis_table_to_save into the table $output_table for the zone $id_zone"
-                    int BATCH_MAX_SIZE = 1000;
+                    int BATCH_MAX_SIZE = 100;
                     ITable inputRes = prepareTableOutput(h2gis_table_to_save, filter, inputSRID, h2gis_datasource, output_table, outputSRID, output_datasource)
                     if (inputRes) {
                         def outputColumns = output_datasource.getTable(output_table).getColumnsTypes();

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/imperviousParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/imperviousParams.json
@@ -2,7 +2,8 @@
   "tags" : {
     "highway": [
         "residential", 
-        "pedestrian"
+        "pedestrian",
+        "rest_area"
     ],
     "amenity": [
         "parking",
@@ -12,7 +13,7 @@
     ],
     "leisure": ["pitch"],
     "railway": ["platform"],
-    "landuse": ["railway","construction"]
+    "landuse": ["railway","construction", "industrial", "commercial"]
   },
   "columns": [
     "highway",

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
@@ -50,7 +50,7 @@ class InputDataFormattingTest {
         assertEquals 44, h2GIS.getTable(extractData.results.railTableName).rowCount
         assertEquals 135, h2GIS.getTable(extractData.results.vegetationTableName).rowCount
         assertEquals 10, h2GIS.getTable(extractData.results.hydroTableName).rowCount
-        assertEquals 45, h2GIS.getTable(extractData.results.imperviousTableName).rowCount
+        assertEquals 47, h2GIS.getTable(extractData.results.imperviousTableName).rowCount
         assertEquals 6, h2GIS.getTable(extractData.results.urbanAreasTableName).rowCount
         assertEquals 0, h2GIS.getTable(extractData.results.coastlineTableName).rowCount
 
@@ -154,7 +154,7 @@ class InputDataFormattingTest {
                 inputTableName: extractData.results.imperviousTableName,
                 epsg          : epsg])
         assertNotNull h2GIS.getTable(format.results.outputTableName).save("./target/osm_impervious_formated.shp", true)
-        assertEquals 45, h2GIS.getTable(format.results.outputTableName).rowCount
+        assertEquals 47, h2GIS.getTable(format.results.outputTableName).rowCount
 
         //Sea/Land mask
         format = OSM.InputDataFormatting.formatSeaLandMask()
@@ -309,7 +309,7 @@ class InputDataFormattingTest {
         assertEquals 44, h2GIS.getTable(extractData.results.railTableName).rowCount
         assertEquals 135, h2GIS.getTable(extractData.results.vegetationTableName).rowCount
         assertEquals 10, h2GIS.getTable(extractData.results.hydroTableName).rowCount
-        assertEquals 45, h2GIS.getTable(extractData.results.imperviousTableName).rowCount
+        assertEquals 47, h2GIS.getTable(extractData.results.imperviousTableName).rowCount
 
         //Buildings with estimation state
         IProcess format = OSM.InputDataFormatting.formatBuildingLayer()

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataLoadingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataLoadingTest.groovy
@@ -59,7 +59,7 @@ class InputDataLoadingTest {
         assertEquals 10, h2GIS.getTable(process.results.hydroTableName).rowCount
 
         //h2GIS.getTable(process.results.imperviousTableName).save("./target/osm_hydro.shp")
-        assertEquals 45, h2GIS.getTable(process.results.imperviousTableName).rowCount
+        assertEquals 47, h2GIS.getTable(process.results.imperviousTableName).rowCount
 
         //h2GIS.getTable(process.results.imperviousTableName).save("./target/osm_hydro.shp")
         assertEquals 6, h2GIS.getTable(process.results.urbanAreasTableName).rowCount


### PR DESCRIPTION
This PR introduces a new method to extraction the impervious areas from the BDTopo 2.2 sources.
It fixes the issue  #774. See the attached image.

Note that the sport areas are poorly documented in BDTopo 2.2. It is not possible to know whether the area is asphalt or grass.  It is therefore sometimes possible that impervious areas are over-represented, especially because the vegetation layer is also missing.

fix also #777

![lorient_impervious](https://user-images.githubusercontent.com/1820572/202676129-91a88eae-7c77-46b4-9d89-14466b67e3f7.png)
