### PR TITLE
Improve impervious areas extraction from OSM

### DIFF
--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
@@ -540,12 +540,11 @@ IProcess formatImperviousLayer() {
         run { datasource, inputTableName, inputZoneEnvelopeTableName, epsg, jsonFilename ->
             debug('Impervious transformation starts')
             def outputTableName = "INPUT_IMPERVIOUS_${UUID.randomUUID().toString().replaceAll("-", "_")}"
-            datasource.execute """Drop table if exists $outputTableName;
-                    CREATE TABLE $outputTableName (THE_GEOM GEOMETRY(POLYGON, $epsg), id_impervious serial);""".toString()
             debug(inputTableName)
             if (inputTableName) {
                 def paramsDefaultFile = this.class.getResourceAsStream("imperviousParams.json")
                 def parametersMap = parametersMapping(jsonFilename, paramsDefaultFile)
+                def mappingTypeAndUse = parametersMap.type
                 def queryMapper = "SELECT "
                 def columnToMap = parametersMap.get("columns")
                 ISpatialTable inputSpatialTable = datasource.getSpatialTable(inputTableName)
@@ -566,42 +565,71 @@ IProcess formatImperviousLayer() {
                     } else {
                         queryMapper += ", st_force2D(a.the_geom) as the_geom FROM $inputTableName  as a"
                     }
-                    def imperviousPrepared = postfix("impervious_prepared")
 
+                    def polygonizedTable = postfix("polygonized")
+                    def polygonizedExploded = postfix("polygonized_exploded")
                     datasource.execute("""  
-                DROP TABLE IF EXISTS $imperviousPrepared;
-                CREATE TABLE $imperviousPrepared as select st_polygonize(st_union(st_accum(ST_ToMultiLine( the_geom)))) as the_geom from 
-            ($queryMapper) as foo where "surface" not in('grass') or "parking" not in ('underground') and "building" is null""".toString())
+                    DROP TABLE IF EXISTS $polygonizedTable;
+                    CREATE TABLE $polygonizedExploded as select st_polygonize(st_union(st_accum(ST_ToMultiLine( the_geom)))) as the_geom from 
+                    ($queryMapper) as foo where "surface" not in('grass') or "parking" not in ('underground') or "building" is null;
+                    DROP TABLE IF EXISTS $polygonizedExploded;
+                    CREATE TABLE $polygonizedExploded as select * from st_explode('$polygonizedTable');
+                    """.toString())
 
+                    def filtered_area = postfix("filtered_area")
+                    datasource.execute("""DROP TABLE IF EXISTS $filtered_area;
+                    CREATE TABLE  $filtered_area AS 
+                    SELECT a.EXPLOD_ID , a.the_geom, st_area(b.the_geom) as area_imp, b.* EXCEPT(the_geom) from $polygonizedExploded as a , $inputTableName as b where
+                    a.the_geom && b.the_geom AND st_intersects(st_pointonsurface(a.the_geom), b.the_geom) ;
+                    CREATE INDEX ON $filtered_area(EXPLOD_ID);""".toString())
+
+                    def impervious_prepared = postfix("impervious_prepared")
+
+                    datasource.execute """Drop table if exists $impervious_prepared;
+                    CREATE TABLE $impervious_prepared (THE_GEOM GEOMETRY(POLYGON, $epsg), id_impervious serial, type varchar);""".toString()
 
                     int rowcount = 1
                     datasource.withBatch(100) { stmt ->
-                        datasource.eachRow("SELECT * FROM $imperviousPrepared".toString()) { row ->
-                            /*def toAdd = true
-                            if ((row.surface != null) && (row.surface == "grass")) {
-                                toAdd = false
-                            }
-                            if ((row.parking != null) && (row.parking == "underground")) {
-                                toAdd = false
-                            }*/
-                            //if (toAdd) {
-                            Geometry geom = row.the_geom
-                            if (!geom.isEmpty()) {
-                                for (int i = 0; i < geom.getNumGeometries(); i++) {
-                                    Geometry subGeom = geom.getGeometryN(i)
-                                    if (!subGeom.isEmpty()) {
-                                        if (subGeom instanceof Polygon) {
-                                            stmt.addBatch "insert into $outputTableName values(ST_GEOMFROMTEXT('${subGeom}',$epsg), ${rowcount++})".toString()
+                        datasource.eachRow("""SELECT 
+                                g1.*
+                                 FROM $filtered_area g1
+                                 LEFT JOIN $filtered_area g2 ON 
+                                    g1.EXPLOD_ID = g2.EXPLOD_ID AND g1.AREA_IMP  > g2.AREA_IMP 
+                                 WHERE g2.EXPLOD_ID  IS NULL
+                                 ORDER BY g1.EXPLOD_ID  ASC""".toString()) { row ->
+                            //println(row)
+                            def typeAndUseValues = getTypeAndUse(row, columnNames, mappingTypeAndUse)
+                            def use = typeAndUseValues[1]
+                            def type = typeAndUseValues[0]
+                            if (type) {
+                                Geometry geom = row.the_geom
+                                if (!geom.isEmpty()) {
+                                    for (int i = 0; i < geom.getNumGeometries(); i++) {
+                                        Geometry subGeom = geom.getGeometryN(i)
+                                        if (!subGeom.isEmpty()) {
+                                            if (subGeom instanceof Polygon) {
+                                                stmt.addBatch "insert into $impervious_prepared values(ST_GEOMFROMTEXT('${subGeom}',$epsg), ${rowcount++}, '${type}')".toString()
+                                            }
                                         }
                                     }
                                 }
                             }
-                            // }
                         }
                     }
-                    datasource.execute("DROP TABLE IF EXISTS  $imperviousPrepared".toString())
+                    //Do the union of all type
+                    datasource.execute("""DROP TABLE IF EXISTS $outputTableName;
+                    CREATE TABLE $outputTableName as SELECT EXPLOD_ID AS id_impervious, THE_GEOM, TYPE
+                    FROM ST_EXPLODE('(
+                    SELECT ST_UNION(ST_ACCUM(the_geom)) as the_geom, TYPE from $impervious_prepared group by type
+                    )');""".toString())
+                    datasource.execute("DROP TABLE IF EXISTS  $polygonizedTable, $filtered_area, $polygonizedExploded, $impervious_prepared".toString())
+
+                    return [outputTableName: outputTableName]
                 }
             }
+            datasource.execute """Drop table if exists $outputTableName;
+                    CREATE TABLE $outputTableName (THE_GEOM GEOMETRY(POLYGON, $epsg), id_impervious serial, type varchar);""".toString()
+
             debug('Impervious transformation finishes')
             [outputTableName: outputTableName]
         }
@@ -903,7 +931,6 @@ static String getSidewalk(String sidewalk) {
  * @return a flat list with escaped elements
  */
 static String columnsMapper(def inputColumns, def columnsToMap) {
-    //def flatList = "\"${inputColumns.join("\",\"")}\""
     def flatList = inputColumns.inject([]) { result, iter ->
         result += "a.\"$iter\""
     }.join(",")

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
@@ -570,7 +570,7 @@ IProcess formatImperviousLayer() {
                     def polygonizedExploded = postfix("polygonized_exploded")
                     datasource.execute("""  
                     DROP TABLE IF EXISTS $polygonizedTable;
-                    CREATE TABLE $polygonizedExploded as select st_polygonize(st_union(st_accum(ST_ToMultiLine( the_geom)))) as the_geom from 
+                    CREATE TABLE $polygonizedTable as select st_polygonize(st_union(st_accum(ST_ToMultiLine( the_geom)))) as the_geom from 
                     ($queryMapper) as foo where "surface" not in('grass') or "parking" not in ('underground') or "building" is null;
                     DROP TABLE IF EXISTS $polygonizedExploded;
                     CREATE TABLE $polygonizedExploded as select * from st_explode('$polygonizedTable');

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataLoading.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataLoading.groovy
@@ -90,7 +90,7 @@ IProcess extractAndCreateGISLayers() {
                     def  keysValues = ["building", "railway", "amenity",
                                        "leisure", "highway", "natural",
                                        "landuse", "landcover",
-                                       "vegetation","waterway"]
+                                       "vegetation","waterway", "area", "aeroway", "area:aeroway"]
                     query =  "[maxsize:1073741824]"+ Utilities.buildOSMQueryWithAllData(envelope, keysValues, OSMElement.NODE, OSMElement.WAY, OSMElement.RELATION)
                 }
 

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -442,7 +442,7 @@ IProcess osm_processing() {
                         def keysValues = ["building", "railway", "amenity",
                                           "leisure", "highway", "natural",
                                           "landuse", "landcover",
-                                          "vegetation", "waterway"]
+                                          "vegetation", "waterway","area", "aeroway", "area:aeroway"]
                         query = "[timeout:$overpass_timeout][maxsize:$overpass_maxsize]" + Utilities.buildOSMQueryWithAllData(zones.envelope, keysValues, OSMElement.NODE, OSMElement.WAY, OSMElement.RELATION)
                     }
 

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/imperviousParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/imperviousParams.json
@@ -13,7 +13,9 @@
     ],
     "leisure": ["pitch"],
     "railway": ["platform"],
-    "landuse": ["railway","construction", "industrial", "commercial"]
+    "landuse": ["railway","construction", "industrial", "commercial"],
+    "area:aeroway": ["runway"],
+    "aeroway": ["apron"]
   },
   "columns": [
     "highway",
@@ -22,6 +24,9 @@
     "area",
     "leisure",
     "parking",
-    "landuse"
+    "landuse",
+    "area:aeroway",
+    "aeroway",
+    "building"
   ]
 }

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/imperviousParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/imperviousParams.json
@@ -28,5 +28,39 @@
     "area:aeroway",
     "aeroway",
     "building"
-  ]
-}
+  ],
+  "type" : {
+    "parking": {
+      "amenity": [
+        "parking",
+        "bicycle_parking",
+        "car_sharing",
+        "parking_place"],
+      "highway": [
+        "rest_area"
+      ]
+    },
+    "industrial": {
+      "landuse": ["railway","construction", "industrial"],
+      "area:aeroway": ["runway"],
+      "aeroway": ["apron"],
+      "railway": ["platform"]
+    },
+    "commercial": {
+      "landuse": [ "commercial"]
+    },
+    "sport": {
+      "leisure": ["pitch"]
+    },
+    "residential": {
+      "highway": [
+        "residential"
+      ]
+    },
+    "pedestrian": {
+      "highway": [
+        "pedestrian"
+      ]
+    }
+  }
+   }

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/roadParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/roadParams.json
@@ -12,11 +12,11 @@
       "road","track","living_street", "pedestrian"
     ],"junction": ["roundabout",
       "circular","jughandle","filter","yes"
-    ]
+    ], "aeroway": ["taxiway"]
   },
   "columns":["width","highway", "surface", "sidewalk",
     "layer","maxspeed","oneway",
-    "route","junction", "bridge", "service", "access", "area"],
+    "route","junction", "bridge", "service", "access", "area", "aeroway"],
     "surface":
      {
         "unpaved": {
@@ -219,7 +219,12 @@
            "highway": [
              "service"
            ]
-         }
+         },
+      "aeroway": {
+        "aeroway": [
+          "taxiway"
+        ]
+      }
     },
     "width" :
      {
@@ -240,7 +245,8 @@
         "roundabout": 4,
         "ferry": 0,
         "pedestrian": 3,
-        "service": 3
+        "service": 3,
+        "aeroway": 18
      },
   "crossing":{"bridge" :
   ["yes", "aqueduct", "cantilever", "covered", "low_water_crossing", "movable", "trestle",

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
@@ -376,6 +376,8 @@ class InputDataFormattingTest {
         //zoneToExtract =[13.4203,120.2165,14.5969 , 122.0293]
         //Le Havre
         zoneToExtract = [49.4370, -0.0230,49.5359,0.2053,]
+        //aeroway Toulouse https://www.openstreetmap.org/way/739797641#map=14/43.6316/1.3590
+        zoneToExtract =  [43.610539,1.334152,43.648808,1.392689]
         IProcess extractData = OSM.InputDataLoading.extractAndCreateGISLayers()
         extractData.execute([
                 datasource   : h2GIS,
@@ -461,13 +463,13 @@ class InputDataFormattingTest {
             h2GIS.getTable(inputWaterTableName).save("${ file.absolutePath+File.separator}osm_hydro_${formatedPlaceName}.geojson", true)
 
             //Impervious
-            /*format = OSM.InputDataFormatting.formatImperviousLayer()
+            format = OSM.InputDataFormatting.formatImperviousLayer()
             format.execute([
                     datasource                : h2GIS,
                     inputTableName            : extractData.results.imperviousTableName,
                     inputZoneEnvelopeTableName: extractData.results.zoneEnvelopeTableName,
                     epsg                      : epsg])
-            h2GIS.getTable(format.results.outputTableName).save("./target/osm_impervious_${formatedPlaceName}.geojson", true)*/
+            h2GIS.getTable(format.results.outputTableName).save("${file.absolutePath+File.separator}osm_impervious_${formatedPlaceName}.geojson", true)
 
 
             //Sea/Land mask


### PR DESCRIPTION
This PR improves the impervious areas extraction.
Now the algorithm separates parking, airport areas, industrial areas and impervious pedestrian areas
Each area is unique and there is no longer any overlap, thanks to polygonize algorithm.

About #783

![impervious_osm](https://user-images.githubusercontent.com/1820572/202909182-d0d61306-73af-4111-8aca-7a698292dfb2.png)
