### PR TITLE
Extend urban areas and new buiding type

### DIFF
--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
@@ -451,6 +451,7 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
                                       svfSimplified     : true,
                                       surface_vegetation: 10000f,
                                       surface_hydro     : 2500f,
+                                      surface_urban_areas: 10000f,
                                       snappingTolerance : 0.01f,
                                       mapOfWeights      : ["sky_view_factor"             : 4,
                                                            "aspect_ratio"                : 3,
@@ -505,6 +506,11 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
                 if (surface_hydroP && surface_hydroP in Number) {
                     rsu_indicators_default.surface_hydro = surface_hydroP
                 }
+                def surface_UrbanAreasP = rsu_indicators.surface_urban_areas
+                if (surface_UrbanAreasP && surface_UrbanAreasP in Number) {
+                    rsu_indicators_default.surface_urban_areas = surface_UrbanAreasP
+                }
+
                 def svfSimplifiedP = rsu_indicators.svfSimplified
                 if (svfSimplifiedP && svfSimplifiedP in Boolean) {
                     rsu_indicators_default.svfSimplified = svfSimplifiedP

--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/InputDataLoading.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/InputDataLoading.groovy
@@ -142,7 +142,7 @@ def loadV2(
     String troncon_voie_ferree = tablesExist.get("troncon_voie_ferree")
     if (!troncon_voie_ferree) {
         troncon_voie_ferree = "troncon_voie_ferree"
-        datasource.execute("DROP TABLE IF EXISTS $troncon_voie_ferree;  CREATE TABLE $troncon_voie_ferree (THE_GEOM geometry(linestring, $srid), ID varchar, NATURE varchar, POS_SOL integer, FRANCHISST varchar,LARGEUR DOUBLE PRECISION);".toString())
+        datasource.execute("DROP TABLE IF EXISTS $troncon_voie_ferree;  CREATE TABLE $troncon_voie_ferree (THE_GEOM geometry(linestring, $srid), ID varchar, NATURE varchar, POS_SOL integer, FRANCHISST varchar,LARGEUR DOUBLE PRECISION, NB_VOIES INTEGER);".toString())
     }
     String surface_eau = tablesExist.get("surface_eau")
     if (!surface_eau) {
@@ -252,7 +252,8 @@ def loadV2(
     datasource.execute("""
             DROP TABLE IF EXISTS INPUT_RAIL;
             CREATE TABLE INPUT_RAIL (THE_GEOM geometry, ID_SOURCE varchar(24), TYPE varchar, ZINDEX integer, CROSSING varchar, WIDTH DOUBLE PRECISION)
-            AS SELECT ST_FORCE2D(ST_MAKEVALID(a.THE_GEOM)) as the_geom, a.ID, a.NATURE, a.POS_SOL, a.FRANCHISST, CASE WHEN a.NB_VOIES = 0 THEN 1.435 ELSE 1.435 * a.NB_VOIES END FROM $troncon_voie_ferree a, $zoneTable b WHERE a.the_geom && b.the_geom AND ST_INTERSECTS(a.the_geom, b.the_geom) and a.POS_SOL>=0;
+            AS SELECT ST_FORCE2D(ST_MAKEVALID(a.THE_GEOM)) as the_geom, a.ID, a.NATURE, a.POS_SOL, a.FRANCHISST, 
+            CASE WHEN a.NB_VOIES = 0 THEN 1.435 ELSE 1.435 * a.NB_VOIES END FROM $troncon_voie_ferree a, $zoneTable b WHERE a.the_geom && b.the_geom AND ST_INTERSECTS(a.the_geom, b.the_geom) and a.POS_SOL>=0;
             """.toString())
 
 
@@ -445,7 +446,7 @@ Map loadV3(JdbcDataSource datasource,
         troncon_de_voie_ferree = "troncon_de_voie_ferree"
         datasource.execute("""DROP TABLE IF EXISTS $troncon_de_voie_ferree;  
                 CREATE TABLE $troncon_de_voie_ferree (THE_GEOM geometry(linestring, $srid), ID varchar, NATURE varchar,
-                POS_SOL integer, FRANCHISST varchar, LARGEUR DOUBLE PRECISION);""".toString())
+                POS_SOL integer, FRANCHISST varchar, LARGEUR DOUBLE PRECISION, NB_VOIES INTEGER);""".toString())
     }
 
     String surface_hydrographique = tablesExist.get("surface_hydrographique")

--- a/common-utils/src/main/groovy/org/orbisgis/geoclimate/utils/AbstractScript.groovy
+++ b/common-utils/src/main/groovy/org/orbisgis/geoclimate/utils/AbstractScript.groovy
@@ -4,6 +4,7 @@ import org.slf4j.Logger
 
 abstract class AbstractScript extends Script {
 
+
     public Logger logger
 
 

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
@@ -184,7 +184,7 @@ String prepareTSUData(JdbcDataSource datasource, String zone, String road, Strin
         return
     }
 
-    if (surface_urban_areas < 10000) {
+    if (surface_urban_areas <= 100) {
         error("The surface of urban areas must be greater or equal than 100 m²")
         return
     }

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
@@ -55,13 +55,15 @@ import static org.h2gis.network.functions.ST_ConnectedComponents.getConnectedCom
  * Expressed in geometry unit of the vegetationTable, default 10000
  * @param surface_hydro A double value to select the hydrographic geometry areas.
  * Expressed in geometry unit of the vegetationTable, default 2500
+ * @param surface_urban_areas A double value to select the urban  areas.
+ * Expressed in geometry unit of the urban_areas table, default 10000
  *
  * @return A database table name and the name of the column ID
  */
 String createTSU(JdbcDataSource datasource, String zone,
                  double area = 1f, String road, String rail, String vegetation,
                  String water, String sea_land_mask,String urban_areas,
-                 double surface_vegetation, double surface_hydro, String prefixName) {
+                 double surface_vegetation, double surface_hydro, double surface_urban_areas, String prefixName) {
     def BASE_NAME = "rsu"
 
     debug "Creating the reference spatial units"
@@ -71,7 +73,7 @@ String createTSU(JdbcDataSource datasource, String zone,
 
     def tsuDataPrepared = prepareTSUData(datasource,
             zone, road, rail,
-            vegetation, water, sea_land_mask, urban_areas, surface_vegetation, surface_hydro, prefixName)
+            vegetation, water, sea_land_mask, urban_areas, surface_vegetation, surface_hydro, surface_urban_areas, prefixName)
     if (!tsuDataPrepared) {
         info "Cannot prepare the data for RSU calculation."
         return
@@ -114,7 +116,7 @@ String createTSU(JdbcDataSource datasource, String inputTableName, String inputz
         error "The input data to compute the TSU cannot be null or empty"
         return null
     }
-    def epsg = datasource.getSpatialTable(inputTableName).srid
+    def epsg = datasource.getSrid(inputTableName)
 
     if (area <= 0) {
         error "The area value to filter the TSU must be greater to 0"
@@ -125,9 +127,9 @@ String createTSU(JdbcDataSource datasource, String inputTableName, String inputz
         datasource """
                     DROP TABLE IF EXISTS $outputTableName;
                     CREATE TABLE $outputTableName AS 
-                        SELECT EXPLOD_ID AS $COLUMN_ID_NAME, ST_SETSRID(a.the_geom, $epsg) AS the_geom
+                        SELECT EXPLOD_ID AS $COLUMN_ID_NAME, ST_SETSRID(ST_BUFFER(a.the_geom,0.01), $epsg) AS the_geom
                         FROM ST_EXPLODE('(
-                                SELECT ST_BUFFER(ST_POLYGONIZE(ST_UNION(ST_NODE(ST_ACCUM(the_geom)))), -0.01) AS the_geom 
+                                SELECT ST_POLYGONIZE(ST_UNION(ST_NODE(ST_ACCUM(the_geom)))) AS the_geom 
                                 FROM $inputTableName)') AS a,
                             $inputzone AS b
                         WHERE a.the_geom && b.the_geom 
@@ -139,7 +141,7 @@ String createTSU(JdbcDataSource datasource, String inputTableName, String inputz
                     CREATE TABLE $outputTableName AS 
                         SELECT EXPLOD_ID AS $COLUMN_ID_NAME, ST_SETSRID(st_buffer(the_geom, -0.01), $epsg) AS the_geom 
                         FROM ST_EXPLODE('(
-                                SELECT ST_BUFFER(ST_POLYGONIZE(ST_UNION(ST_NODE(ST_ACCUM(the_geom)))),-0.01) AS the_geom 
+                                SELECT ST_POLYGONIZE(ST_UNION(ST_NODE(ST_ACCUM(the_geom)))) AS the_geom 
                                 FROM $inputTableName)') where st_area(the_geom) > $area""".toString()
     }
 
@@ -171,7 +173,8 @@ String createTSU(JdbcDataSource datasource, String inputTableName, String inputz
  */
 String prepareTSUData(JdbcDataSource datasource, String zone, String road, String rail,
                       String vegetation, String water, String sea_land_mask, String urban_areas,
-                      double surface_vegetation, double surface_hydro, String prefixName = "unified_abstract_model") {
+                      double surface_vegetation, double surface_hydro, double surface_urban_areas, String prefixName = "unified_abstract_model") {
+
     if (surface_vegetation <= 100) {
         error("The surface of vegetation must be greater or equal than 100 m²")
         return
@@ -180,6 +183,12 @@ String prepareTSUData(JdbcDataSource datasource, String zone, String road, Strin
         error("The surface of water must be greater or equal than 100 m²")
         return
     }
+
+    if (surface_urban_areas < 10000) {
+        error("The surface of urban areas must be greater or equal than 100 m²")
+        return
+    }
+
     def BASE_NAME = "prepared_tsu_data"
 
     debug "Preparing the abstract model to build the TSU"
@@ -326,8 +335,7 @@ String prepareTSUData(JdbcDataSource datasource, String zone, String road, Strin
         if (water && datasource.hasTable(urban_areas)) {
             if (datasource.getColumnNames(urban_areas).size() > 0) {
                 debug "Preparing urban areas..."
-                queryCreateOutputTable += [urban_areas_tmp: "(SELECT ST_ToMultiLine(THE_GEOM) FROM $urban_areas)"]
-
+                queryCreateOutputTable += [urban_areas_tmp: "(SELECT ST_ToMultiLine(THE_GEOM) FROM $urban_areas WHERE st_area(the_geom)>=$surface_urban_areas and type not in ('social_building'))"]
             }
         }
 

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -1029,7 +1029,8 @@ Map createUnitsOfAnalysis(JdbcDataSource datasource, String zone, String buildin
                           String road, String rail, String vegetation,
                           String water, String  sea_land_mask, String urban_areas,
                           String rsu, double surface_vegetation,
-                          double surface_hydro, double snappingTolerance, List indicatorUse = ["LCZ", "UTRF", "TEB"], String prefixName = "") {
+                          double surface_hydro, double surface_urban_areas,
+                          double snappingTolerance, List indicatorUse = ["LCZ", "UTRF", "TEB"], String prefixName = "") {
     info "Create the units of analysis..."
     def idRsu = "id_rsu"
     def tablesToDrop = []
@@ -1038,7 +1039,7 @@ Map createUnitsOfAnalysis(JdbcDataSource datasource, String zone, String buildin
         rsu = Geoindicators.SpatialUnits.createTSU(datasource, zone, road, rail,
                 vegetation, water,
                 sea_land_mask, urban_areas, surface_vegetation,
-                surface_hydro, prefixName)
+                surface_hydro,surface_urban_areas, prefixName)
         if (!rsu) {
             info "Cannot compute the RSU."
             return
@@ -1111,7 +1112,7 @@ Map createUnitsOfAnalysis(JdbcDataSource datasource, String zone, String buildin
  */
 Map getParameters() {
     return [
-            "surface_vegetation"            : 10000d, "surface_hydro": 2500d,
+            "surface_vegetation"            : 10000d, "surface_hydro": 2500d, "surface_urban_areas":10000d,
             "snappingTolerance"             : 0.01d, "indicatorUse": ["LCZ", "UTRF", "TEB"],
             "mapOfWeights"                  : ["sky_view_factor"             : 1, "aspect_ratio": 1, "building_surface_fraction": 1,
                                                "impervious_surface_fraction" : 1, "pervious_surface_fraction": 1,
@@ -1218,6 +1219,7 @@ Map computeAllGeoIndicators(JdbcDataSource datasource, String zone, String build
 
     def surface_vegetation = inputParameters.surface_vegetation
     def surface_hydro = inputParameters.surface_hydro
+    def surface_urban_areas = inputParameters.surface_urban_areas
     def snappingTolerance = inputParameters.snappingTolerance
     def buildingHeightModelName = inputParameters.buildingHeightModelName
     def indicatorUse = inputParameters.indicatorUse
@@ -1239,7 +1241,7 @@ Map computeAllGeoIndicators(JdbcDataSource datasource, String zone, String build
                 water, impervious,
                 buildingEstimateTableName,
                 sea_land_mask, urban_areas, rsuTable,
-                surface_vegetation, surface_hydro,
+                surface_vegetation, surface_hydro,surface_urban_areas,
                 snappingTolerance,
                 buildingHeightModelName, prefixName)
         if (!estimHeight) {
@@ -1280,7 +1282,7 @@ Map computeAllGeoIndicators(JdbcDataSource datasource, String zone, String build
                     vegetation,
                     water, sea_land_mask, "", rsuTable,
                     surface_vegetation,
-                    surface_hydro, snappingTolerance, indicatorUse,
+                    surface_hydro, surface_urban_areas, snappingTolerance, indicatorUse,
                     prefixName)
             if (!spatialUnitsForCalc) {
                 error "Cannot create the spatial units"
@@ -1330,7 +1332,7 @@ Map computeAllGeoIndicators(JdbcDataSource datasource, String zone, String build
                 rail, vegetation,
                 water, sea_land_mask, "","",
                 surface_vegetation,
-                surface_hydro, snappingTolerance, indicatorUse,
+                surface_hydro,surface_urban_areas, snappingTolerance, indicatorUse,
                 prefixName)
         if (!spatialUnits) {
             error "Cannot create the spatial units"
@@ -1367,7 +1369,7 @@ Map estimateBuildingHeight(JdbcDataSource datasource, String zone, String buildi
                            String water, String impervious,
                            String building_estimate, String sea_land_mask, String urban_areas, String rsu,
                            double surface_vegetation, double surface_hydro,
-                           double snappingTolerance, String buildingHeightModelName, String prefixName = "") {
+                           double snappingTolerance, double surface_urban_areas, String buildingHeightModelName, String prefixName = "") {
     if (!building_estimate) {
         error "To estimate the building height a table that contains the list of building to estimate must be provided"
         return
@@ -1382,7 +1384,7 @@ Map estimateBuildingHeight(JdbcDataSource datasource, String zone, String buildi
     Map spatialUnits = createUnitsOfAnalysis(datasource, zone,
             building, road, rail, vegetation,
             water, sea_land_mask, urban_areas, rsu,
-            surface_vegetation, surface_hydro, snappingTolerance, ["UTRF"],
+            surface_vegetation, surface_hydro,surface_urban_areas, snappingTolerance, ["UTRF"],
             prefixName)
     if (!spatialUnits) {
         error "Cannot create the spatial units"

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -1368,8 +1368,8 @@ Map estimateBuildingHeight(JdbcDataSource datasource, String zone, String buildi
                            String road, String rail, String vegetation,
                            String water, String impervious,
                            String building_estimate, String sea_land_mask, String urban_areas, String rsu,
-                           double surface_vegetation, double surface_hydro,
-                           double snappingTolerance, double surface_urban_areas, String buildingHeightModelName, String prefixName = "") {
+                           double surface_vegetation, double surface_hydro,double surface_urban_areas,
+                           double snappingTolerance, String buildingHeightModelName, String prefixName = "") {
     if (!building_estimate) {
         error "To estimate the building height a table that contains the list of building to estimate must be provided"
         return

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/RsuIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/RsuIndicatorsTests.groovy
@@ -414,7 +414,7 @@ class RsuIndicatorsTests {
         def outputTableGeoms = Geoindicators.SpatialUnits.prepareTSUData(h2GIS,
                 'zone_test', 'road_test', '',
                 'veget_test', 'hydro_test', "","",
-                10000, 2500, "prepare_rsu")
+                10000, 2500,10000, "prepare_rsu")
 
         assertNotNull h2GIS.getTable(outputTableGeoms)
 

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnitsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnitsTests.groovy
@@ -80,7 +80,7 @@ class SpatialUnitsTests {
         def outputTableGeoms = Geoindicators.SpatialUnits.prepareTSUData(h2GIS,
                 'zone_test', 'road_test', 'rail_test',
                 'veget_test', 'hydro_test', "","",
-                10000, 2500, "block")
+                10000, 2500,10000, "block")
 
         assertNotNull(outputTableGeoms)
 
@@ -103,7 +103,7 @@ class SpatialUnitsTests {
         def createRSU = Geoindicators.SpatialUnits.createTSU(h2GIS, "zone_test",
                 'road_test', 'rail_test',
                 'veget_test', 'hydro_test',
-                "","", 10000, 2500, "block")
+                "","", 10000, 2500,10000, "block")
         assert createRSU
 
         assert h2GIS.getSpatialTable(createRSU).save(new File(folder, "rsu.shp").getAbsolutePath(), true)
@@ -188,7 +188,7 @@ class SpatialUnitsTests {
 
         def outputTableGeoms = Geoindicators.SpatialUnits.prepareTSUData(h2GIS,
                 'zone_test', 'road_test', 'rail_test', 'veget_test',
-                'hydro_test', "", "",10000, 2500, "block")
+                'hydro_test', "", "",10000, 2500, 10000, "block")
 
 
         assertNotNull(outputTableGeoms)

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicatorsTest.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicatorsTest.groovy
@@ -489,15 +489,15 @@ class WorkflowGeoIndicatorsTest {
     def checkRSUIndicators(def datasource, def rsuIndicatorsTableName) {
         //Check road_fraction > 0
         def countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE ROAD_FRACTION>0".toString())
-        assertEquals(184, countResult.count)
+        assertEquals(195, countResult.count)
 
         //Check building_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE BUILDING_FRACTION>0".toString())
-        assertEquals(70, countResult.count)
+        assertEquals(73, countResult.count)
 
         //Check high_vegetation_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE high_vegetation_fraction>0".toString())
-        assertEquals(18, countResult.count)
+        assertEquals(43, countResult.count)
 
         //Check high_vegetation_water_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE high_vegetation_water_fraction>0".toString())
@@ -513,7 +513,7 @@ class WorkflowGeoIndicatorsTest {
 
         //Check high_vegetation_road_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE high_vegetation_road_fraction>0".toString())
-        assertEquals(20, countResult.count)
+        assertEquals(43, countResult.count)
 
         //Check high_vegetation_impervious_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE high_vegetation_impervious_fraction>0".toString())
@@ -525,7 +525,7 @@ class WorkflowGeoIndicatorsTest {
 
         //Check low_vegetation_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE low_vegetation_fraction>0".toString())
-        assertEquals(50, countResult.count)
+        assertEquals(76, countResult.count)
 
         //Check low_vegetation_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE impervious_fraction>0".toString())

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataLoading.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataLoading.groovy
@@ -244,13 +244,12 @@ Map createGISLayers(JdbcDataSource datasource, String osmFilePath, org.locationt
             datasource.execute("ALTER TABLE ${impervious} RENAME TO $outputImperviousTableName".toString())
             info "Impervious layer created"
         }
-
         //Create urban areas layer
         paramsDefaultFile = this.class.getResourceAsStream("urbanAreasParams.json")
         parametersMap = readJSONParameters(paramsDefaultFile)
         tags = parametersMap.get("tags")
         columnsToKeep = parametersMap.get("columns")
-        String urban_areas = OSMTools.Transform.toPolygons(datasource, prefix, epsg, tags, [],geometry, true)
+        String urban_areas = OSMTools.Transform.toPolygons(datasource, prefix, epsg, tags,columnsToKeep,geometry, true)
         debug "Create the urban areas layer"
         if (urban_areas) {
             outputUrbanAreasTableName = postfix("OSM_URBAN_AREAS")

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -753,6 +753,7 @@ def extractProcessingParameters(def processing_parameters) {
                                   svfSimplified     : true,
                                   surface_vegetation: 10000f,
                                   surface_hydro     : 2500f,
+                                  surface_urban_areas  : 10000f,
                                   snappingTolerance : 0.01f,
                                   mapOfWeights      : ["sky_view_factor"             : 4,
                                                        "aspect_ratio"                : 3,
@@ -808,6 +809,11 @@ def extractProcessingParameters(def processing_parameters) {
             if (surface_hydroP && surface_hydroP in Number) {
                 rsu_indicators_default.surface_hydro = surface_hydroP
             }
+            def surface_urbanAreasP = rsu_indicators.surface_urban_areas
+            if (surface_urbanAreasP && surface_urbanAreasP in Number) {
+                rsu_indicators_default.surface_urban_areas = surface_urbanAreasP
+            }
+
             def svfSimplifiedP = rsu_indicators.svfSimplified
             if (svfSimplifiedP && svfSimplifiedP in Boolean) {
                 rsu_indicators_default.svfSimplified = svfSimplifiedP

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/buildingParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/buildingParams.json
@@ -37,7 +37,8 @@
     "sustenance",
     "office",
     "tourism",
-    "roof:shape"
+    "roof:shape",
+    "wall"
   ],
   "level": {
     "building": 1,
@@ -82,7 +83,9 @@
     "emergency": 0,
     "hotel": 2,
     "hospital": 2,
-    "parking": 1
+    "parking": 1,
+    "slight_construction": 0,
+    "water_tower" : 0
   },
   "type": {
     "terminal:transport": {
@@ -597,7 +600,7 @@
         "community_centre", "conference_centre",
         "events_venue", "exhibition_centre", "gambling",
         "music_venue", "nightclub", "planetarium",
-        "social_centre","studio", "theatre"
+        "social_centre","studio", "theatre", "library"
       ],
       "building": [
         "cinema","arts_centre", "brothel", "casino",
@@ -605,6 +608,8 @@
         "events_venue", "exhibition_centre", "gambling",
         "music_venue", "nightclub", "planetarium",
         "social_centre","studio", "theatre"
+      ], "tourism": [
+        "museum", "aquarium", "gallery", "information"
       ]
     },
     "sustenance:commercial": {
@@ -650,7 +655,7 @@
         "! no"
       ]
     },
-    "building:public": {
+    "government:public": {
       "building": [
         "public"
       ]
@@ -672,6 +677,12 @@
       "tourism": [
         "attraction"
       ]
+    },
+    "slight_construction": {
+      "wall": ["no"]
+    },
+    "water:service": {
+      "man_made": ["water_tower"]
     },
     "building": {
       "building": [

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/urbanAreasParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/urbanAreasParams.json
@@ -1,18 +1,13 @@
 {
   "tags": {
-    "landuse": [
-      "commercial",
-      "residential",
-      "retail",
-      "industrial",
-      "construction"
-    ],
+    "landuse": [],
     "construction":[]
   },
   "columns": [
     "landuse",
     "industrial",
-    "construction"
+    "construction",
+    "anemity"
   ],
   "type": {
     "construction": {
@@ -39,6 +34,26 @@
     "light_industry:industrial": {
       "landuse": [
         "industrial"
+      ]
+    },
+    "government": {
+      "landuse": [
+        "institutional"
+      ]
+    },
+    "education": {
+      "landuse": [
+        "education"
+      ],
+      "amenity": [
+        "school",
+        "university",
+        "research_institute"
+      ]
+    },
+    "military": {
+      "landuse": [
+        "military"
       ]
     }
   }

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/urbanAreasParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/urbanAreasParams.json
@@ -1,15 +1,34 @@
 {
   "tags": {
-    "landuse": [],
-    "construction":[]
+    "landuse": [ "commercial",
+      "residential",
+      "retail",
+      "industrial",
+      "construction", "military",
+      "railway", "farmyard"],
+    "construction":[],
+    "amenity": ["school",
+      "university",
+      "research_institute", "community_centre"]
   },
   "columns": [
     "landuse",
     "industrial",
     "construction",
-    "anemity"
+    "amenity",
+    "building"
   ],
   "type": {
+    "education": {
+      "landuse": [
+        "education"
+      ],
+      "amenity": [
+        "school",
+        "university",
+        "research_institute"
+      ]
+    },
     "construction": {
       "landuse": [
         "construction"
@@ -26,14 +45,14 @@
         "residential"
       ]
     },
-    "heavy_industry:industrial": {
+    "heavy_industry": {
       "industrial": [
         "refinery"
       ]
     },
-    "light_industry:industrial": {
+    "light_industry": {
       "landuse": [
-        "industrial"
+        "industrial", "port"
       ]
     },
     "government": {
@@ -41,19 +60,23 @@
         "institutional"
       ]
     },
-    "education": {
-      "landuse": [
-        "education"
-      ],
-      "amenity": [
-        "school",
-        "university",
-        "research_institute"
-      ]
-    },
+    "social_building": {
+    "amenity": [
+      "community_centre"
+    ]},
     "military": {
       "landuse": [
         "military"
+      ]
+    },
+    "transport": {
+      "landuse": [
+        "railway"
+      ]
+    },
+    "agricultural": {
+      "landuse": [
+        "farmyard"
       ]
     }
   }

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
@@ -67,7 +67,7 @@ class InputDataFormattingTest {
         assertEquals 136, h2GIS.getTable(extractData.vegetation).rowCount
         assertEquals 10, h2GIS.getTable(extractData.water).rowCount
         assertEquals 47, h2GIS.getTable(extractData.impervious).rowCount
-        assertEquals 7, h2GIS.getTable(extractData.urban_areas).rowCount
+        assertEquals 11, h2GIS.getTable(extractData.urban_areas).rowCount
         assertEquals 0, h2GIS.getTable(extractData.coastline).rowCount
 
         //Buildings
@@ -312,7 +312,9 @@ class InputDataFormattingTest {
         zoneToExtract = "Göteborgs Stad"
 
         zoneToExtract = "Riantec"
-        zoneToExtract =[45.575525,5.913734,45.578859,5.919549]
+        zoneToExtract =[45.185546,5.751944,45.204296,5.784216]
+
+       zoneToExtract="Sassenage"
 
         Map extractData = OSM.InputDataLoading.extractAndCreateGISLayers(h2GIS, zoneToExtract)
 

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataLoadingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataLoadingTest.groovy
@@ -66,7 +66,7 @@ class InputDataLoadingTest {
 
         assertEquals 47, h2GIS.getTable(extract.impervious).rowCount
 
-        assertEquals 7, h2GIS.getTable(extract.urban_areas).rowCount
+        assertEquals 11, h2GIS.getTable(extract.urban_areas).rowCount
     }
 
     //This test is used for debug purpose

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -645,18 +645,14 @@ class WorflowOSMTest extends WorkflowAbstractTest {
     //Use it for debug
     @Test
     void testIntegration() {
-
         String directory = "/tmp/geoclimate"
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
         def location = "Nice"
-
        //def nominatim = OSMTools.Utilities.getNominatimData("Nantes")
-
-        location=[47.2, -1.6, 47.4, -1.4]
+        location="Sassenage"
        //location = nominatim.bbox
-
 
         def osm_parmeters = [
                 "description" : "Example of configuration file to run the OSM workflow and store the result in a folder",
@@ -678,7 +674,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                         ["distance"                                             : 0,
                          "rsu_indicators"                                       : [
 
-                                 "indicatorUse": ["LCZ", "TEB"] //, "UTRF", "TEB"]
+                                 "indicatorUse": ["LCZ"] //, "UTRF", "TEB"]
 
                          ]/*,"grid_indicators": [
                                 "x_size": 200,
@@ -776,41 +772,6 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         def subFolder = new File(outputFolder.getAbsolutePath() + File.separator + "osm_" + id_zone)
         Geoindicators.WorkflowUtilities.saveToAscGrid("grid_indicators", subFolder, "grid_indicators", datasource, 3007, reproject, deleteOutputData)
     }
-
-    @Disabled
-    @Test
-    void testPopulation_Indicators() {
-        String directory = "/tmp/geoclimate"
-        File dirFile = new File(directory)
-        dirFile.delete()
-        dirFile.mkdir()
-        //H2GIS h2gis = H2GIS.open("${directory+File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
-        //h2gis.load("../cities/Barcelona/lden_barcelona_ref.geojson", "area_zone", true)
-        //def env = h2gis.firstRow("(select st_transform(st_extent(the_geom), 4326) as the_geom from area_zone)").the_geom.getEnvelopeInternal()
-        //def location = [[env.getMinY()as float, env.getMinX() as float, env.getMaxY() as float, env.getMaxX() as float]];
-        def location = [[57.651096, 11.821976, 57.708916, 11.89235]]
-        def tables = ["building", "population", "road_traffic"]
-        tables = ["road_traffic"]
-        def osm_parmeters = [
-                "description" : "Example of configuration file to run only the road traffic estimation",
-                "geoclimatedb": [
-                        "folder": dirFile.absolutePath,
-                        "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
-                        "delete": false
-                ],
-                "input"       : [
-                        "locations": location],
-                "output"      : [
-                        "folder": ["path"  : directory,
-                                   "tables": tables]],
-                "parameters"  :
-                        ["worldpop_indicators": false, "road_traffic": true]
-        ]
-        OSM.workflow(osm_parmeters)
-        //assertEquals(10,  process.getResults().output["Pont-de-Veyle"].size())
-        //assertTrue h2gis.firstRow("select count(*) as count from ${process.results.output["Pont-de-Veyle"].population} where pop is not null").count>0
-    }
-
 
     @Test
     //Integration tests

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorkflowAbstractTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorkflowAbstractTest.groovy
@@ -52,7 +52,7 @@ class WorkflowAbstractTest {
         Map spatialUnits = Geoindicators.WorkflowGeoIndicators.createUnitsOfAnalysis(datasource, zone, buildingTableName,
                 roadTableName, railTableName, vegetationTableName,
                 hydrographicTableName, sealandmaskTableName, urban_areas, "", 10000,
-                2500, 0.01, indicatorUse, prefixName)
+                2500, 10000, 0.01, indicatorUse, prefixName)
 
         String relationBuildings = spatialUnits.building
         String relationBlocks = spatialUnits.block

--- a/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/Utilities.groovy
+++ b/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/Utilities.groovy
@@ -269,11 +269,7 @@ boolean executeNominatimQuery(def query, def outputOSMFile) {
         connection = url.openConnection()
     }
     connection.requestMethod = "GET"
-    def user_agent = System.getProperty("OVERPASS_USER_AGENT")
-    if (!user_agent) {
-        user_agent = OSM_USER_AGENT
-    }
-    connection.setRequestProperty("User-Agent", user_agent)
+    connection.setRequestProperty("User-Agent", "GEOCLIMATE_${System.currentTimeMillis()}")
 
     connection.connect()
 
@@ -691,9 +687,6 @@ static @Field OVERPASS_BASE_URL = "${OVERPASS_ENDPOINT}/interpreter?data="
 /** Url of the status of the Overpass server */
 static @Field OVERPASS_STATUS_URL = "${OVERPASS_ENDPOINT}/status"
 
-/** Default user agent*/
-static @Field OSM_USER_AGENT = "geoclimate"
-
 /** OVERPASS TIMEOUT */
 static @Field int OVERPASS_TIMEOUT = 180
 /**
@@ -760,11 +753,7 @@ boolean executeOverPassQuery(URL queryUrl, def outputOSMFile) {
         timeout = (int) TimeUnit.MINUTES.toMillis(3);
     }
 
-    def user_agent = System.getProperty("OVERPASS_USER_AGENT")
-    if (!user_agent) {
-        user_agent = OSM_USER_AGENT
-    }
-    connection.setRequestProperty("User-Agent", user_agent)
+    connection.setRequestProperty("User-Agent", "GEOCLIMATE_${System.currentTimeMillis()}")
 
     connection.setConnectTimeout(timeout);
     connection.setReadTimeout(timeout);
@@ -826,11 +815,8 @@ boolean executeOverPassQuery(def query, def outputOSMFile) {
     } else {
         timeout = (int) TimeUnit.MINUTES.toMillis(3);
     }
-    def user_agent = System.getProperty("OVERPASS_USER_AGENT")
-    if (!user_agent) {
-        user_agent = OSM_USER_AGENT
-    }
-    connection.setRequestProperty("User-Agent", user_agent)
+    connection.setRequestProperty("User-Agent", "GEOCLIMATE_${System.currentTimeMillis()}")
+
     connection.setConnectTimeout(timeout)
     connection.setReadTimeout(timeout)
 

--- a/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/LoaderTest.groovy
+++ b/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/LoaderTest.groovy
@@ -635,4 +635,13 @@ class LoaderTest extends AbstractOSMToolsTest {
             }
         }
     }
+
+    /**
+     * For debug purpose
+     */
+    @Disabled
+    @Test
+    void forDebug() {
+        println(OSMTools.Utilities.getNominatimData("Sassenage"))
+    }
 }

--- a/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/LoaderTest.groovy
+++ b/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/LoaderTest.groovy
@@ -221,32 +221,33 @@ class LoaderTest extends AbstractOSMToolsTest {
      */
     @Test
     void fromPlaceNoDistTest() {
-        def placeName = "Lezoen, Plourivo"
-        def formattedPlaceName = "Lezoen_Plourivo_"
+        if(OSMTools.Utilities.isNominatimReady()) {
+            def placeName = "Lezoen, Plourivo"
+            def formattedPlaceName = "Lezoen_Plourivo_"
+            Map r = OSMTools.Loader.fromPlace(ds, placeName)
+            assertFalse r.isEmpty()
+            assertTrue r.containsKey("zone")
+            assertTrue r.containsKey("envelope")
+            assertTrue r.containsKey("prefix")
+            assertTrue Pattern.compile("OSM_DATA_$formattedPlaceName$uuidRegex").matcher(r.prefix as String).matches()
 
-        Map r = OSMTools.Loader.fromPlace(ds, placeName)
-        assertFalse r.isEmpty()
-        assertTrue r.containsKey("zone")
-        assertTrue r.containsKey("envelope")
-        assertTrue r.containsKey("prefix")
-        assertTrue Pattern.compile("OSM_DATA_$formattedPlaceName$uuidRegex").matcher(r.prefix as String).matches()
+            def zone = ds.getSpatialTable(r.zone)
+            assertEquals 1, zone.rowCount
+            assertEquals 2, zone.getColumnCount()
+            assertTrue zone.columns.contains("THE_GEOM")
+            assertTrue zone.columns.contains("ID_ZONE")
+            zone.next()
+            assertNotNull zone.getGeometry(1)
 
-        def zone = ds.getSpatialTable(r.zone)
-        assertEquals 1, zone.rowCount
-        assertEquals 2, zone.getColumnCount()
-        assertTrue zone.columns.contains("THE_GEOM")
-        assertTrue zone.columns.contains("ID_ZONE")
-        zone.next()
-        assertNotNull zone.getGeometry(1)
-
-        def zoneEnv = ds.getSpatialTable(r.envelope)
-        assertEquals 1, zoneEnv.rowCount
-        assertEquals 2, zoneEnv.getColumnCount()
-        assertTrue zoneEnv.columns.contains("THE_GEOM")
-        assertTrue zoneEnv.columns.contains("ID_ZONE")
-        zoneEnv.next()
-        assertEquals "POLYGON ((-3.0790622 48.7298266, -3.0790622 48.7367393, -3.0739517 48.7367393, -3.0739517 48.7298266, -3.0790622 48.7298266))", zoneEnv.getGeometry(1).toText()
-        assertEquals "Lezoen, Plourivo", zoneEnv.getString(2)
+            def zoneEnv = ds.getSpatialTable(r.envelope)
+            assertEquals 1, zoneEnv.rowCount
+            assertEquals 2, zoneEnv.getColumnCount()
+            assertTrue zoneEnv.columns.contains("THE_GEOM")
+            assertTrue zoneEnv.columns.contains("ID_ZONE")
+            zoneEnv.next()
+            assertEquals "POLYGON ((-3.0790622 48.7298266, -3.0790622 48.7367393, -3.0739517 48.7367393, -3.0739517 48.7298266, -3.0790622 48.7298266))", zoneEnv.getGeometry(1).toText()
+            assertEquals "Lezoen, Plourivo", zoneEnv.getString(2)
+        }
     }
 
     /**

--- a/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/TransformTest.groovy
+++ b/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/TransformTest.groovy
@@ -608,11 +608,11 @@ class TransformTest extends AbstractOSMToolsTest {
             def extract = OSMTools.Loader.extract(query)
             if (extract) {
                 def prefix = "OSM_FILE_${OSMTools.Utilities.uuid()}"
-                if (OSMTools.Loader.load(h2GIS, prefix, extract)) {
+                if (OSMTools.Loader.load(ds, prefix, extract)) {
                     def tags = ['building']
                     def transform = OSMTools.Transform.toPolygons(h2GIS, prefix, tags)
                     assertNotNull(transform)
-                    assertTrue(h2GIS.getTable(transform).getRowCount() > 0)
+                    assertTrue(ds.getTable(transform).getRowCount() > 0)
                 }
             }
         }
@@ -873,6 +873,23 @@ class TransformTest extends AbstractOSMToolsTest {
                     h2GIS.getTable(outputTableName).save("/tmp/results.shp", true)
 
                 }
+            }
+        }
+    }
+
+    @Test
+    void buildAllPolygons() {
+        def bbox =[47.647353,-2.090192,47.649413,-2.087274]
+        def query = OSMTools.Utilities.buildOSMQuery(bbox)
+        if (!query.isEmpty()) {
+            def extract = OSMTools.Loader.extract(query)
+            if (extract) {
+                def prefix = "OSM"
+                assertTrue OSMTools.Loader.load(ds, prefix,extract)
+                //Create building layer
+                def tags = ["amenity", "landuse", "railway", "water"]
+                String outputTableName = OSMTools.Transform.toPolygons(ds, prefix, 4326, tags)
+                ds.save(outputTableName, "/tmp/polygons.geojson", true)
             }
         }
     }

--- a/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/utils/UtilitiesTest.groovy
+++ b/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/utils/UtilitiesTest.groovy
@@ -548,12 +548,12 @@ class UtilitiesTest extends AbstractOSMToolsTest {
     @Disabled
     void getNominatimDataTest() {
         def pattern = Pattern.compile("^POLYGON \\(\\((?>-?\\d+(?>\\.\\d+)? -?\\d+(?>\\.\\d+)?(?>, )?)*\\)\\)\$")
-        def data = Utilities.getNominatimData("Paimpol")
+        def data = OSMTools.Utilities.getNominatimData("Paimpol")
         assertTrue pattern.matcher(data["geom"].toString()).matches()
         Envelope env = data["geom"].getEnvelopeInternal()
         assertEquals([env.getMinY(), env.getMinX(), env.getMaxY(), env.getMaxX()].toString(), data["bbox"].toString())
         assertEquals(data["extratags"]["ref:INSEE"], "22162")
-        data = Utilities.getNominatimData("Boston")
+        data = OSMTools.Utilities.getNominatimData("Boston")
         assertTrue pattern.matcher(data["geom"].toString()).matches()
         assertEquals(data["extratags"]["population"], "689326")
     }

--- a/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/utils/UtilitiesTest.groovy
+++ b/osmtools/src/test/groovy/org/orbisgis/geoclimate/osmtools/utils/UtilitiesTest.groovy
@@ -278,9 +278,12 @@ class UtilitiesTest extends AbstractOSMToolsTest {
                 "out;", OSMTools.Utilities.buildOSMQuery(enveloppe, ["building", "water"], OSMElement.NODE, OSMElement.WAY)
         assertEquals "[bbox:7.6,0.0,8.9,2.3];\n" +
                 "(\n" +
+                "\tnode[\"building\"];\n" +
+                "\tway[\"building\"];\n" +
+                "\trelation[\"building\"];\n" +
                 ");\n" +
                 "(._;>;);\n" +
-                "out;", OSMTools.Utilities.buildOSMQuery(enveloppe, ["building", "water"])
+                "out;", OSMTools.Utilities.buildOSMQuery(enveloppe, ["building"])
         assertEquals "[bbox:7.6,0.0,8.9,2.3];\n" +
                 "(\n" +
                 ");\n" +
@@ -315,19 +318,19 @@ class UtilitiesTest extends AbstractOSMToolsTest {
                 "\tway[\"water\"];\n" +
                 ");\n" +
                 ">;);\n" +
-                "out;", Utilities.buildOSMQueryWithAllData(enveloppe, ["building", "water"], OSMElement.NODE, OSMElement.WAY)
+                "out;", OSMTools.Utilities.buildOSMQueryWithAllData(enveloppe, ["building", "water"], OSMElement.NODE, OSMElement.WAY)
         assertEquals "[bbox:7.6,0.0,8.9,2.3];\n" +
                 "((\n" +
                 ");\n" +
                 ">;);\n" +
-                "out;", Utilities.buildOSMQueryWithAllData(enveloppe, ["building", "water"])
+                "out;", OSMTools.Utilities.buildOSMQueryWithAllData(enveloppe, ["building", "water"])
         assertEquals "[bbox:7.6,0.0,8.9,2.3];\n" +
                 "((\n" +
                 "\tnode;\n" +
                 "\tway;\n" +
                 ");\n" +
                 ">;);\n" +
-                "out;", Utilities.buildOSMQueryWithAllData(enveloppe, [], OSMElement.NODE, OSMElement.WAY)
+                "out;", OSMTools.Utilities.buildOSMQueryWithAllData(enveloppe, [], OSMElement.NODE, OSMElement.WAY)
     }
 
     /**
@@ -366,9 +369,12 @@ class UtilitiesTest extends AbstractOSMToolsTest {
                 "out;", OSMTools.Utilities.buildOSMQuery(polygon, ["building", "water"], OSMElement.NODE, OSMElement.WAY)
         assertEquals "[bbox:2.3,0.0,8.9,7.6];\n" +
                 "(\n" +
+                "\tnode[\"building\"](poly:\"2.3 0.0 2.3 7.6 8.9 7.6 8.9 0.0\");\n" +
+                "\tway[\"building\"](poly:\"2.3 0.0 2.3 7.6 8.9 7.6 8.9 0.0\");\n" +
+                "\trelation[\"building\"](poly:\"2.3 0.0 2.3 7.6 8.9 7.6 8.9 0.0\");\n" +
                 ");\n" +
                 "(._;>;);\n" +
-                "out;", OSMTools.Utilities.buildOSMQuery(polygon, ["building", "water"])
+                "out;", OSMTools.Utilities.buildOSMQuery(polygon, ["building"])
         assertEquals "[bbox:2.3,0.0,8.9,7.6];\n" +
                 "(\n" +
                 ");\n" +


### PR DESCRIPTION
This PR enhances the urban areas layer by adding new types as  transport, social_building (zone de salle des fêtes pour les français), education (school, university, research_institute).  
Because urban areas can overlap, a vertical merge process has been added taking into account the overlaping areas and the types. For example, an education type always has priority over a residential zone. 
The building types has been added to describe water building, shelter...

The urban areas are used to build the TSU. As for water and vegetation geometries the urban areas can be filtered with a surface parameter.