### PR TITLE
OSM and BDTopo data extraction options

### DIFF
--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -663,6 +663,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                 "input"       : [
                         "locations": [location],//["Pont-de-Veyle"],//[nominatim["bbox"]],//["Lorient"],
                          "area": 2800,
+                        //"date":"2017-12-31T19:20:00Z",
                         /*"timeout":182,
                         "maxsize": 536870918,
                         "endpoint":"https://lz4.overpass-api.de/api"*/],
@@ -794,6 +795,66 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                 ],
                 "input"       : [
                         "locations": [[43.726898,7.298452,43.727677,7.299632]]],
+                "output"      : [
+                        "folder": ["path"  : directory,
+                                   "tables": ["building", "zone"]]],
+                "parameters"  :
+                        ["distance"       : 0,
+                         rsu_indicators: ["indicatorUse" : ["LCZ"]]
+                        ]
+        ]
+        Map process = OSM.WorkflowOSM.workflow(osm_parmeters)
+        def tableNames = process.values()
+        def building = tableNames.building[0]
+        H2GIS h2gis = H2GIS.open("${directory + File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
+        assertTrue h2gis.firstRow("select count(*) as count from $building where HEIGHT_WALL>0 and HEIGHT_ROOF>0").count > 0
+    }
+
+    @Test
+    void testEstimateBuildingWithAllInputHeightFromPoint() {
+        String directory = folder.absolutePath + File.separator + "test_building_height"
+        File dirFile = new File(directory)
+        dirFile.delete()
+        dirFile.mkdir()
+        def osm_parmeters = [
+                "geoclimatedb": [
+                        "folder": dirFile.absolutePath,
+                        "name"  : "geoclimate_chain_db",
+                        "delete": false
+                ],
+                "input"       : [
+                        "locations": [[43.726898,7.298452,100]]],
+                "output"      : [
+                        "folder": ["path"  : directory,
+                                   "tables": ["building", "zone"]]],
+                "parameters"  :
+                        [
+                         rsu_indicators: ["indicatorUse" : ["LCZ"]]
+                        ]
+        ]
+        Map process = OSM.WorkflowOSM.workflow(osm_parmeters)
+        def tableNames = process.values()
+        def building = tableNames.building[0]
+        H2GIS h2gis = H2GIS.open("${directory + File.separator}geoclimate_chain_db;AUTO_SERVER=TRUE")
+        assertTrue h2gis.firstRow("select count(*) as count from $building where HEIGHT_WALL>0 and HEIGHT_ROOF>0").count > 0
+    }
+
+    @Disabled //Because it takes some time to build the OSM query
+    @Test
+    void testEstimateBuildingWithAllInputHeightDate() {
+        String directory = folder.absolutePath + File.separator + "test_building_height"
+        File dirFile = new File(directory)
+        dirFile.delete()
+        dirFile.mkdir()
+        def osm_parmeters = [
+                "geoclimatedb": [
+                        "folder": dirFile.absolutePath,
+                        "name"  : "geoclimate_chain_db",
+                        "delete": false
+                ],
+                "input"       : [
+                        "locations": [[43.726898,7.298452,43.727677,7.299632]],
+                        "date":"2015-12-31T19:20:00Z"],
                 "output"      : [
                         "folder": ["path"  : directory,
                                    "tables": ["building", "zone"]]],

--- a/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/Utilities.groovy
+++ b/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/Utilities.groovy
@@ -653,7 +653,8 @@ Geometry geometryFromValues(def bbox) {
         return buildGeometry([bbox[1], bbox[0], bbox[3], bbox[2]]);
     }
     else if (bbox.size()==3){
-        if(bbox[2]<=0){
+        if(bbox[2]<100){
+            error("The distance to create a bbox from a point must be greater than 100 meters")
             return null
         }
         return getAreaFromPoint(bbox[1], bbox[0], bbox[2])

--- a/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/Utilities.groovy
+++ b/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/Utilities.groovy
@@ -653,6 +653,9 @@ Geometry geometryFromValues(def bbox) {
         return buildGeometry([bbox[1], bbox[0], bbox[3], bbox[2]]);
     }
     else if (bbox.size()==3){
+        if(bbox[2]<=0){
+            return null
+        }
         return getAreaFromPoint(bbox[1], bbox[0], bbox[2])
     }
 }

--- a/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/Utilities.groovy
+++ b/osmtools/src/main/groovy/org/orbisgis/geoclimate/osmtools/utils/Utilities.groovy
@@ -638,7 +638,8 @@ Geometry geometryFromNominatim(def bbox) {
  *
  * @author Erwan Bocher (CNRS LAB-STICC)
  *
- * @param bbox 4 values to define a bbox
+ * @param bbox 4 values to define a bbox or 3 values to define a point (lat/long)
+ * with a distance around it, expressed in meters
  * @return a JTS polygon
  */
 Geometry geometryFromValues(def bbox) {
@@ -650,6 +651,9 @@ Geometry geometryFromValues(def bbox) {
     }
     if (bbox.size() == 4) {
         return buildGeometry([bbox[1], bbox[0], bbox[3], bbox[2]]);
+    }
+    else if (bbox.size()==3){
+        return getAreaFromPoint(bbox[1], bbox[0], bbox[2])
     }
 }
 


### PR DESCRIPTION
This PR introduces two new options to process OSM data

1. date : to query the osm db from a specific date expressed in ISO 8601

2.  location with 3 values to specify a point in lat/lon plus a distance

**Pseudo config file for option 1**

```
 [
             "input"       : [
                        "locations": [[43.726898,7.298452,43.727677,7.299632]],
                        "date":"2015-12-31T19:20:00Z"],
                "output"      : [
                        "folder": ["path"  : directory,
                                   "tables": ["building", "zone"]]],
                "parameters"  :
                        ["distance"       : 0,
                         rsu_indicators: ["indicatorUse" : ["LCZ"]]
                        ]
        ]
```

**Pseudo config file for option 2**

```
[
                "input"       : [
                        "locations": [[43.726898,7.298452,100]]],
                "output"      : [
                        "folder": ["path"  : directory,
                                   "tables": ["building", "zone"]]],
                "parameters"  :
                        [
                         rsu_indicators: ["indicatorUse" : ["LCZ"]]
                        ]
        ]
```
