### PR TITLE
Allow formating GIS layers from the workflow config file

### DIFF
--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
@@ -441,7 +441,7 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
      * @return a filled map of parameters
      */
     def extractProcessingParameters(def processing_parameters) {
-        def defaultParameters = [distance       : 1000f, prefixName: "",
+        def defaultParameters = [distance       : 500f, prefixName: "",
                                  hLevMin        : 3]
         def rsu_indicators_default = [indicatorUse       : [],
                                       svfSimplified      : true,

--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
@@ -160,9 +160,6 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
 
         //Get processing parameters
         def processing_parameters = extractProcessingParameters(parameters.parameters)
-        if (!processing_parameters) {
-            return
-        }
 
         //Get the out put parameters
         def outputDatasource
@@ -444,8 +441,7 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
      * @return a filled map of parameters
      */
     def extractProcessingParameters(def processing_parameters) {
-        def defaultParameters = [distance       : 1000f,
-                                 distance_buffer: 500f, prefixName: "",
+        def defaultParameters = [distance       : 1000f, prefixName: "",
                                  hLevMin        : 3]
         def rsu_indicators_default = [indicatorUse       : [],
                                       svfSimplified      : true,
@@ -461,7 +457,6 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
                                                             "height_of_roughness_elements": 6,
                                                             "terrain_roughness_length"    : 0.5],
                                       utrfModelName      : "UTRF_BDTOPO_V2_RF_2_2.model"]
-        defaultParameters.put("rsu_indicators", rsu_indicators_default)
 
         if (processing_parameters) {
             def distanceP = processing_parameters.distance
@@ -526,10 +521,9 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
                         rsu_indicators_default.mapOfWeights = mapOfWeightsP
                     }
                 }
-            } else {
-                rsu_indicators = rsu_indicators_default
-            }
+                defaultParameters.put("rsu_indicators", rsu_indicators_default)
 
+            }
 
             //Check for grid indicators
             def grid_indicators = processing_parameters.grid_indicators
@@ -949,7 +943,7 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
             results.put("building", building)
 
             //Compute the RSU indicators
-            if (rsu_indicators_params.indicatorUse) {
+            if (rsu_indicators_params && rsu_indicators_params.indicatorUse) {
                 //Build the indicators
                 rsu_indicators_params.put("utrfModelName", "UTRF_BDTOPO_V2_RF_2_2.model")
                 Map geoIndicators = Geoindicators.WorkflowGeoIndicators.computeAllGeoIndicators(h2gis_datasource, zone,

--- a/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/WorkflowAbstractTest.groovy
+++ b/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/WorkflowAbstractTest.groovy
@@ -389,4 +389,51 @@ abstract class WorkflowAbstractTest {
         checkFormatData()
     }
 
+    @Test
+    void testOnlyFormatData() {
+        String dataFolder = getDataFolderPath()
+        def bdTopoParameters = [
+                "description" : "Workflow format data",
+                "geoclimatedb": [
+                        "folder": folder.absolutePath,
+                        "name"  : "testFormat;AUTO_SERVER=TRUE",
+                        "delete": false
+                ],
+                "input"       : [
+                        "folder"   : dataFolder,
+                        "locations": [getInseeCode()]],
+                "output"      : [
+                        "folder": ["path": folder.absolutePath]]
+        ]
+
+        Map process = BDTopo.workflow(bdTopoParameters, getVersion())
+        assertNotNull(process)
+
+        def tableNames = process[getInseeCode()]
+        assertTrue(tableNames.size() > 0)
+        H2GIS h2gis = H2GIS.open(folder.absolutePath + File.separator + "testFormat;AUTO_SERVER=TRUE")
+
+        //Test zone
+        assertTrue h2gis.firstRow("select count(*) as count from ${tableNames.zone} where the_geom is not null").count > 0
+
+        //Test building
+        String building_table = tableNames.building
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from $building_table where TYPE is not null;""".toString()).count > 0)
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from $building_table where MAIN_USE is not null;""".toString()).count > 0)
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from $building_table where NB_LEV is not null or NB_LEV>0 ;""".toString()).count > 0)
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from $building_table where HEIGHT_WALL is not null or HEIGHT_WALL>0 ;""".toString()).count > 0)
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from $building_table where HEIGHT_ROOF is not null or HEIGHT_ROOF>0 ;""".toString()).count > 0)
+
+        //Test water
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from ${tableNames.water} where TYPE is not null;""".toString()).count > 0)
+
+        //Test vegetation
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from ${tableNames.vegetation} where TYPE is not null;""".toString()).count > 0)
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from ${tableNames.vegetation} where HEIGHT_CLASS is not null;""".toString()).count > 0)
+
+        //Test road
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from ${tableNames.road} where TYPE is not null;""".toString()).count > 0)
+        assertTrue(h2gis.firstRow("""SELECT count(*) as count from ${tableNames.road} where WIDTH is not null or WIDTH>0 ;""".toString()).count > 0)
+     }
+
 }

--- a/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/v2/WorkflowBDTopoV2Test.groovy
+++ b/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/v2/WorkflowBDTopoV2Test.groovy
@@ -132,7 +132,5 @@ class WorkflowBDTopoV2Test extends WorkflowAbstractTest {
         assertEquals(count, h2GIS.firstRow("SELECT COUNT(*) as count FROM urban_areas where type is not null").count)
         assertEquals(count, h2GIS.firstRow("SELECT COUNT(*) as count FROM urban_areas where ST_ISEMPTY(THE_GEOM)=false OR THE_GEOM IS NOT NULL").count)
 
-
-
     }
 }


### PR DESCRIPTION
It's now possible to use GeoClimate workflow just to prepare the GIS layers.
Unit tests added 