### PR TITLE
Improve urban_sprawl_areas and urban_cool_areas computation

### DIFF
--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
@@ -871,7 +871,10 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
                     Map sprawl_indic = Geoindicators.WorkflowGeoIndicators.sprawlIndicators(h2gis_datasource, rasterizedIndicators, "id_grid", grid_indicators_params.indicators,
                             Math.max(x_size, y_size).floatValue())
                     if (sprawl_indic) {
-                        results.put("sprawl_areas", sprawl_indic.sprawl_areas)
+                        results.put("urban_sprawl_areas", sprawl_indic.urban_sprawl_areas)
+                        if (sprawl_indic.urban_cool_areas) {
+                            results.put("urban_cool_areas", sprawl_indic.urban_cool_areas)
+                        }
                         results.put("grid_indicators", sprawl_indic.grid_indicators)
                     }
                     info("End computing grid_indicators")

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
@@ -656,7 +656,7 @@ String computeSprawlAreas(JdbcDataSource datasource, String grid_indicators,
         create table $outputTableName as 
         select  CAST((row_number() over()) as Integer) as id, st_removeholes(the_geom) as the_geom from ST_EXPLODE('(
         select st_union(st_accum(the_geom)) as the_geom from
-        $grid_indicators where  LCZ_PRIMARY NOT IN (101, 102,103,104,106, 107))')""".toString())
+        $grid_indicators where  LCZ_PRIMARY NOT IN (101, 102,103,104,106, 107))') WHERE  the_geom is not null or st_isempty(the_geom) = false""".toString())
             return outputTableName
         } else {
             def tmp_sprawl = postfix("sprawl_tmp")
@@ -677,7 +677,8 @@ String computeSprawlAreas(JdbcDataSource datasource, String grid_indicators,
         st_removeholes(st_buffer(st_union(st_accum(st_buffer(st_removeholes(the_geom),$distance, ''quad_segs=2 endcap=flat
                      join=mitre mitre_limit=2''))),
                      -$distance, ''quad_segs=2 endcap=flat join=mitre mitre_limit=2'')) as the_geom  
-         FROM ST_EXPLODE(''$tmp_sprawl'') )') where st_area(st_buffer(the_geom, -$distance,2)) >${distance * distance};
+         FROM ST_EXPLODE(''$tmp_sprawl'') )') where (the_geom is not null or
+         st_isempty(the_geom) = false) and st_area(st_buffer(the_geom, -$distance,2)) >${distance * distance};
         DROP TABLE IF EXISTS $tmp_sprawl;
         """.toString())
             return outputTableName
@@ -702,34 +703,62 @@ String inversePolygonsLayer(JdbcDataSource datasource, String input_polygons) th
     FROM
     ST_EXPLODE('(
         select st_difference(a.the_geom, st_accum(b.the_geom)) as the_geom from $tmp_extent as a, $input_polygons
-        as b where st_dimension(b.the_geom)=2)');        
+        as b where st_dimension(b.the_geom)=2)') where st_isempty(the_geom) = false or the_geom is not null;        
     DROP TABLE IF EXISTS $tmp_extent;
+    """.toString())
+    return outputTableName
+}
+
+/**
+ * This method is used to compute the difference between an input layer of polygons and the bounding box
+ * of the input layer.
+ * @param input_polygons a layer that contains polygons
+ * @param polygons_to_remove the polygons to remove in the input_polygons table
+ * @author Erwan Bocher (CNRS)
+ */
+String inversePolygonsLayer(JdbcDataSource datasource, String input_polygons, String polygons_to_remove) throws Exception {
+    def outputTableName = postfix("inverse_geometries")
+    datasource.createSpatialIndex(input_polygons)
+    datasource.createSpatialIndex(polygons_to_remove)
+    datasource.execute("""DROP TABLE IF EXISTS $outputTableName;
+    CREATE TABLE $outputTableName as
+    SELECT CAST((row_number() over()) as Integer) as id, the_geom
+    FROM
+    ST_EXPLODE('(
+        select st_difference(a.the_geom, st_accum(b.the_geom)) as the_geom from $input_polygons as a, $polygons_to_remove
+        as b where a.the_geom && b.the_geom and st_intersects(a.the_geom, st_pointonsurface(b.the_geom)) group by a.the_geom)')
+    where the_geom is not null or st_isempty(the_geom) = false;   
     """.toString())
     return outputTableName
 }
 
 
 /**
- * This methods allows to extract the cool area geometries
+ * This methods allows to extract the cool area geometries inside a set of geometries,
+ * defined in a polygon mask table
  * A cool area is a continous geometry defined by the LCZ 101, 102, 103,104, 106 and 107.
  *
  *
  * @author Erwan Bocher (CNRS)
  */
-String extractCoolAreas(JdbcDataSource datasource, String grid_indicators,
+String extractCoolAreas(JdbcDataSource datasource, String grid_indicators,String polygons_mask,
                         float distance = 50) throws Exception {
-    if (!grid_indicators) {
+    if (!grid_indicators || !polygons_mask) {
         throw new IllegalArgumentException("No grid_indicators table to extract the cool areas layer")
     }
     def gridCols = datasource.getColumnNames(grid_indicators)
     if (gridCols.contains("LCZ_PRIMARY")) {
+        datasource.createSpatialIndex(polygons_mask)
+        datasource.createSpatialIndex(grid_indicators)
         def outputTableName = postfix("cool_areas")
         datasource.execute("""
         DROP TABLE IF EXISTS $outputTableName;
         CREATE TABLE $outputTableName as SELECT CAST((row_number() over()) as Integer) as id,  the_geom FROM ST_EXPLODE('(
-        SELECT ST_UNION(ST_ACCUM(a.THE_GEOM)) AS THE_GEOM FROM $grid_indicators as a
+        SELECT ST_UNION(ST_ACCUM(a.THE_GEOM)) AS THE_GEOM FROM $grid_indicators as a, $polygons_mask as b
         where 
-         a.LCZ_PRIMARY in (101, 102, 103,104, 106, 107))') ${distance > 0 ? " where st_area(st_buffer(the_geom, -$distance,2)) >${distance * distance}" : ""};
+         a.LCZ_PRIMARY in (101, 102, 103,104, 106, 107) and
+         a.the_geom && b.the_geom and st_intersects(st_pointonsurface(a.the_geom), b.the_geom))') ${distance > 0 ? 
+                " where (the_geom is not null or st_isempty(the_geom) = false) and st_area(st_buffer(the_geom, -$distance,2)) >${distance * distance}" : ""};
         """.toString())
         return outputTableName
     }

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -2185,7 +2185,7 @@ Map sprawlIndicators(JdbcDataSource datasource, String grid_indicators, String i
     String sprawl_areas
     String cool_areas
     if (list_indicators_upper.intersect(["URBAN_SPRAWL_AREAS", "URBAN_SPRAWL_DISTANCES", "URBAN_SPRAWL_COOL_DISTANCE"]) && grid_indicators) {
-        sprawl_areas = Geoindicators.SpatialUnits.computeSprawlAreas(datasource, grid_indicators, (distance / 2) as float)
+        sprawl_areas = Geoindicators.SpatialUnits.computeSprawlAreas(datasource, grid_indicators, distance )
     }
     if (sprawl_areas) {
         //Compute the distances
@@ -2211,7 +2211,7 @@ Map sprawlIndicators(JdbcDataSource datasource, String grid_indicators, String i
         if (list_indicators_upper.contains("URBAN_SPRAWL_COOL_DISTANCE")) {
             cool_areas = Geoindicators.SpatialUnits.extractCoolAreas(datasource, grid_indicators, (distance / 2) as float)
             if (cool_areas) {
-                String inverse_cool_areas = Geoindicators.SpatialUnits.inversePolygonsLayer(datasource, cool_areas)
+                String inverse_cool_areas = Geoindicators.SpatialUnits.inversePolygonsLayer(datasource, cool_areas, sprawl_areas)
                 if (inverse_cool_areas) {
                     tablesToDrop << inverse_cool_areas
                     String cool_distances = Geoindicators.GridIndicators.gridDistances(datasource, inverse_cool_areas, grid_indicators, id_grid, false)

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -2207,11 +2207,10 @@ Map sprawlIndicators(JdbcDataSource datasource, String grid_indicators, String i
                 }
             }
         }
-
         if (list_indicators_upper.contains("URBAN_SPRAWL_COOL_DISTANCE")) {
-            cool_areas = Geoindicators.SpatialUnits.extractCoolAreas(datasource, grid_indicators, (distance / 2) as float)
+            cool_areas = Geoindicators.SpatialUnits.extractCoolAreas(datasource, grid_indicators, sprawl_areas, (distance / 2) as float)
             if (cool_areas) {
-                String inverse_cool_areas = Geoindicators.SpatialUnits.inversePolygonsLayer(datasource, cool_areas, sprawl_areas)
+                String inverse_cool_areas = Geoindicators.SpatialUnits.inversePolygonsLayer(datasource, sprawl_areas,cool_areas)
                 if (inverse_cool_areas) {
                     tablesToDrop << inverse_cool_areas
                     String cool_distances = Geoindicators.GridIndicators.gridDistances(datasource, inverse_cool_areas, grid_indicators, id_grid, false)

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnitsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnitsTests.groovy
@@ -253,12 +253,13 @@ class SpatialUnitsTests {
         h2GIS.execute("""
         --Grid values
         DROP TABLE IF EXISTS grid;
-        CREATE TABLE grid AS SELECT  * EXCEPT(ID), id as id_grid, 104 AS LCZ_PRIMARY FROM 
+        CREATE TABLE grid AS SELECT  * EXCEPT(ID), id as id_grid, 105 AS LCZ_PRIMARY FROM 
         ST_MakeGrid('POLYGON((0 0, 9 0, 9 9, 0 0))'::GEOMETRY, 1, 1);
         """.toString())
         String sprawl_areas = Geoindicators.SpatialUnits.computeSprawlAreas(h2GIS, "grid", 0)
+        h2GIS.save(sprawl_areas, "/tmp/sprawl.fgb", true)
         assertEquals(1, h2GIS.firstRow("select count(*) as count from $sprawl_areas".toString()).count)
-        assertTrue(h2GIS.firstRow("select st_union(st_accum(the_geom)) as the_geom from $sprawl_areas".toString()).the_geom.isEmpty())
+        assertEquals(81, h2GIS.firstRow("select st_union(st_accum(the_geom)) as the_geom from $sprawl_areas".toString()).the_geom.getArea())
     }
 
     @Test
@@ -304,8 +305,8 @@ class SpatialUnitsTests {
         UPDATE grid SET LCZ_PRIMARY= 1  WHERE id_row = 1 AND id_col = 1; 
         """.toString())
         String sprawl_areas = Geoindicators.SpatialUnits.computeSprawlAreas(h2GIS, "grid", 0)
-        assertEquals(1, h2GIS.firstRow("select count(*) as count from $sprawl_areas".toString()).count)
-        assertEquals(9, h2GIS.firstRow("select st_area(st_accum(the_geom)) as area from $sprawl_areas".toString()).area, 0.0001)
+        assertEquals(3, h2GIS.firstRow("select count(*) as count from $sprawl_areas".toString()).count)
+        assertEquals(11, h2GIS.firstRow("select st_area(st_accum(the_geom)) as area from $sprawl_areas".toString()).area, 0.0001)
     }
 
     @Test

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnitsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnitsTests.groovy
@@ -363,9 +363,9 @@ class SpatialUnitsTests {
         h2GIS.save(distances, "/tmp/distances.fgb", true)
 
         //Method to compute the cool areas distances
-        String cool_areas = Geoindicators.SpatialUnits.extractCoolAreas(h2GIS, grid_scales)
+        String cool_areas = Geoindicators.SpatialUnits.extractCoolAreas(h2GIS, grid_scales, sprawl_areas)
         h2GIS.save(cool_areas, "/tmp/cool_areas.fgb", true)
-        String inverse_cool_areas = Geoindicators.SpatialUnits.inversePolygonsLayer(h2GIS, cool_areas)
+        String inverse_cool_areas = Geoindicators.SpatialUnits.inversePolygonsLayer(h2GIS, sprawl_areas, cool_areas)
         h2GIS.save(inverse_cool_areas, "/tmp/inverse_cool_areas.fgb", true)
         distances = Geoindicators.GridIndicators.gridDistances(h2GIS, inverse_cool_areas, grid_scales, "id_grid")
         h2GIS.save(distances, "/tmp/cool_inverse_distances.fgb", true)

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicatorsTest.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicatorsTest.groovy
@@ -522,7 +522,7 @@ class WorkflowGeoIndicatorsTest {
         String grid = Geoindicators.WorkflowGeoIndicators.createGrid(datasource, datasource.getExtent("building"), 10, 10, 0)
         assertNotNull(grid)
         String grid_indicators = Geoindicators.WorkflowGeoIndicators.rasterizeIndicators(datasource, grid, [],
-                null, "building", null, null, null, null, null,
+                "building", null, null, null, null, null,
                 null, null, null)
         assertNull(grid_indicators)
         def list_indicators = ["BUILDING_FRACTION", "BUILDING_HEIGHT", "BUILDING_POP",
@@ -531,8 +531,8 @@ class WorkflowGeoIndicatorsTest {
                                "BUILDING_HEIGHT_WEIGHTED", "BUILDING_SURFACE_DENSITY",
                                "SEA_LAND_FRACTION", "ASPECT_RATIO", "SVF",
                                "HEIGHT_OF_ROUGHNESS_ELEMENTS", "TERRAIN_ROUGHNESS_CLASS"]
-        grid_indicators = Geoindicators.WorkflowGeoIndicators.rasterizeIndicators(datasource, grid, list_indicators, null,
-                "building", null, null, null, null, null, null,
+        grid_indicators = Geoindicators.WorkflowGeoIndicators.rasterizeIndicators(datasource, grid, list_indicators,
+                "building", null, null, null, null, null,
                 null, null, null)
         assertNotNull(grid_indicators)
         assertEquals(1, datasource.getRowCount(grid_indicators))

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
@@ -1079,7 +1079,6 @@ String formatUrbanAreas(JdbcDataSource datasource, String urban_areas, String zo
                 }
             }
             //Merging urban_areas
-
             def mergingUrbanAreas = postfix("merging_urban_areas")
             datasource.execute("""
             CREATE TABLE $mergingUrbanAreas as select CAST((row_number() over()) as Integer) as id_urban,the_geom, type from 

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -959,7 +959,7 @@ def saveOutputFiles(def h2gis_datasource, def id_zone, def results, def outputFi
     } else {
         FileUtilities.deleteFiles(subFolder)
     }
-    outputFiles.each {
+    outputFiles.each { it->
         if (it == "grid_indicators") {
             if (outputGrid == "fgb") {
                 Geoindicators.WorkflowUtilities.saveInFile(results."$it", "${subFolder.getAbsolutePath() + File.separator + it}.fgb", h2gis_datasource, outputSRID, reproject, deleteOutputData)

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -445,7 +445,7 @@ Map osm_processing(JdbcDataSource h2gis_datasource, def processing_parameters, d
 
                 info "Urban areas formatted"
                 /*
-                 * Do not filter the data when formatting becausethe job is already done when extracting osm data                     *
+                 * Do not filter the data when formatting because the job is already done when extracting osm data                     *
                  */
                 Map formatBuilding = OSM.InputDataFormatting.formatBuildingLayer(
                         h2gis_datasource, gisLayersResults.building,
@@ -597,7 +597,7 @@ Map osm_processing(JdbcDataSource h2gis_datasource, def processing_parameters, d
                 if (grid_indicators_params) {
                     info("Start computing grid_indicators")
                     if (!geomEnv) {
-                        geomEnv = h2gis_datasource.getSpatialTable(utm_zone_table).getExtent()
+                        geomEnv = h2gis_datasource.getExtent(utm_zone_table)
                     }
                     outputGrid = grid_indicators_params.output
                     def x_size = grid_indicators_params.x_size


### PR DESCRIPTION
This PR fixes the computation of urban_cool_areas plus their distances. The urban_sprawl_areas geometries is used to apply a mask when the urban_cool_distance is computed. 
A table urban_cool_areas is now saved as an output file or table in a database.