### PR TITLE
Add TARGET model input

### DIFF
--- a/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/WorkflowAbstractTest.groovy
+++ b/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/WorkflowAbstractTest.groovy
@@ -92,7 +92,7 @@ abstract class WorkflowAbstractTest {
         def bdTopoParameters = [
                 "description" : "Full workflow configuration file",
                 "geoclimatedb": [
-                        "folder": folder.absolutePath,
+                        "folder": getDBFolderPath(),
                         "name"  : "testFullWorflow;AUTO_SERVER=TRUE",
                         "delete": false
                 ],
@@ -100,7 +100,7 @@ abstract class WorkflowAbstractTest {
                         "folder"   : dataFolder,
                         "locations": [getInseeCode()]],
                 "output"      : [
-                        "folder": ["path": folder.absolutePath]],
+                        "folder": ["path": getDBFolderPath()]],
                 "parameters"  :
                         ["distance"        : 0,
                          rsu_indicators    : [
@@ -122,7 +122,7 @@ abstract class WorkflowAbstractTest {
 
         def tableNames = process[getInseeCode()]
         assertTrue(tableNames.size() > 0)
-        H2GIS h2gis = H2GIS.open(folder.absolutePath + File.separator + "testFullWorflow;AUTO_SERVER=TRUE")
+        H2GIS h2gis = H2GIS.open(getDBFolderPath() + File.separator + "testFullWorflow;AUTO_SERVER=TRUE")
 
         //Test zone
         assertTrue h2gis.firstRow("select count(*) as count from ${tableNames.zone} where the_geom is not null").count > 0
@@ -170,7 +170,7 @@ abstract class WorkflowAbstractTest {
         def filePath = getClass().getResource(getFolderName() + File.separator + "COMMUNE.shp")
         // If some layers are missing, do not try to load them...
         if (filePath) {
-            H2GIS h2GIS = H2GIS.open(folder.absolutePath + File.separator + "tmpdb")
+            H2GIS h2GIS = H2GIS.open(getDBFolderPath() + File.separator + "tmpdb")
             h2GIS.link(filePath, "COMMUNE", true)
             Geometry geom = h2GIS.firstRow("""SELECT ST_BUFFER(ST_POINTONSURFACE(the_geom), 200) AS the_geom from commune""".toString()).the_geom
             h2GIS.close()
@@ -180,7 +180,7 @@ abstract class WorkflowAbstractTest {
             def bdTopoParameters = [
                     "description" : "Example of configuration file to set the SRID",
                     "geoclimatedb": [
-                            "folder": folder.absolutePath,
+                            "folder": getDBFolderPath(),
                             "name"  : "testFullWorflowSRID;AUTO_SERVER=TRUE",
                             "delete": false
                     ],
@@ -188,7 +188,7 @@ abstract class WorkflowAbstractTest {
                             "folder"   : dataFolder,
                             "locations": [location]],
                     "output"      : [
-                            "folder": ["path": folder.absolutePath, "tables": ["grid_indicators"]],
+                            "folder": ["path": getDBFolderPath(), "tables": ["grid_indicators"]],
                             "srid"  : 4326],
                     "parameters"  :
                             ["distance"       : 0,
@@ -208,10 +208,10 @@ abstract class WorkflowAbstractTest {
             def tableNames = process.values()
             def grid_table = tableNames.grid_indicators[0]
             assertNotNull(grid_table)
-            H2GIS h2gis = H2GIS.open("${folder.absolutePath + File.separator}testFullWorflowSRID;AUTO_SERVER=TRUE")
+            H2GIS h2gis = H2GIS.open("${getDBFolderPath() + File.separator}testFullWorflowSRID;AUTO_SERVER=TRUE")
             assertTrue h2gis.firstRow("select count(*) as count from $grid_table".toString()).count == 100
             assertTrue h2gis.firstRow("select count(*) as count from $grid_table where BUILDING_FRACTION>0".toString()).count > 0
-            File grid_file = new File(folder.absolutePath + File.separator + "bdtopo_" + getVersion() + "_" + location.join("_") + File.separator + "grid_indicators.fgb")
+            File grid_file = new File(getDBFolderPath() + File.separator + "bdtopo_" + getVersion() + "_" + location.join("_") + File.separator + "grid_indicators.fgb")
             assertTrue(grid_file.exists())
             h2gis.load(grid_file.absolutePath, "grid_indicators_file", true)
             assertEquals(4326, h2gis.getSpatialTable("grid_indicators_file").srid)
@@ -220,7 +220,7 @@ abstract class WorkflowAbstractTest {
 
     @Test
     void workflowExternalDB() {
-        def externaldb_dbProperties = [databaseName: "${folder.absolutePath + File.separator}external_db",
+        def externaldb_dbProperties = [databaseName: "${getDBFolderPath() + File.separator}external_db",
                                        user        : 'sa',
                                        password    : 'sa'
         ]
@@ -230,13 +230,13 @@ abstract class WorkflowAbstractTest {
                             "zone"               : "zone",
                             "grid_indicators"    : "grid_indicators"]
         //Drop all output tables if exist
-        H2GIS externalDB = H2GIS.open(folder.absolutePath + File.separator + externaldb_dbProperties.databaseName,
+        H2GIS externalDB = H2GIS.open(getDBFolderPath() + File.separator + externaldb_dbProperties.databaseName,
                 externaldb_dbProperties.user, externaldb_dbProperties.password)
         externalDB.execute("DROP TABLE IF EXISTS ${outputTables.values().join(",")};".toString())
         def bdTopoParameters = [
                 "description" : "Example of configuration file to run the BDTopo workflow and store the results in a folder",
                 "geoclimatedb": [
-                        "folder": folder.getAbsolutePath(),
+                        "folder": getDBFolderPath(),
                         "name"  : "bdtopo_workflow_db;AUTO_SERVER=TRUE",
                         "delete": true
                 ],
@@ -247,7 +247,7 @@ abstract class WorkflowAbstractTest {
                         "database":
                                 ["user"        : externaldb_dbProperties.user,
                                  "password"    : externaldb_dbProperties.password,
-                                 "databaseName": folder.absolutePath + File.separator + externaldb_dbProperties.databaseName,
+                                 "databaseName": getDBFolderPath() + File.separator + externaldb_dbProperties.databaseName,
                                  "tables"      : outputTables]],
                 "parameters"  :
                         ["distance"       : 0,
@@ -280,11 +280,11 @@ abstract class WorkflowAbstractTest {
         def filePath = getClass().getResource(getFolderName() + File.separator + "COMMUNE.shp")
         // If some layers are missing, do not try to load them...
         if (filePath) {
-            def externaldb_dbProperties = [databaseName: "${folder.absolutePath + File.separator}external_db_bbox",
+            def externaldb_dbProperties = [databaseName: "${getDBFolderPath() + File.separator}external_db_bbox",
                                            user        : 'sa',
                                            password    : 'sa'
             ]
-            H2GIS externalDB = H2GIS.open(folder.absolutePath + File.separator + externaldb_dbProperties.databaseName, externaldb_dbProperties.user, externaldb_dbProperties.password)
+            H2GIS externalDB = H2GIS.open(getDBFolderPath() + File.separator + externaldb_dbProperties.databaseName, externaldb_dbProperties.user, externaldb_dbProperties.password)
             externalDB.link(filePath, "COMMUNE", true)
             Geometry geom = externalDB.firstRow("""SELECT ST_BUFFER(ST_POINTONSURFACE(the_geom), 200) AS the_geom from commune""".toString()).the_geom
 
@@ -300,7 +300,7 @@ abstract class WorkflowAbstractTest {
             def bdTopoParameters = [
                     "description" : "Example of configuration file to run the BDTopo workflow and store the results in a folder",
                     "geoclimatedb": [
-                            "folder": folder.absolutePath,
+                            "folder": getDBFolderPath(),
                             "name"  : "bdtopo_workflow_db_bbox;AUTO_SERVER=TRUE",
                             "delete": true
                     ],
@@ -311,7 +311,7 @@ abstract class WorkflowAbstractTest {
                             "database":
                                     ["user"        : externaldb_dbProperties.user,
                                      "password"    : externaldb_dbProperties.password,
-                                     "databaseName": folder.absolutePath + File.separator + externaldb_dbProperties.databaseName,
+                                     "databaseName": getDBFolderPath() + File.separator + externaldb_dbProperties.databaseName,
                                      "tables"      : outputTables]],
                     "parameters"  :
                             ["distance"       : 0,
@@ -344,7 +344,7 @@ abstract class WorkflowAbstractTest {
         def bdTopoParameters = [
                 "description" : "Example of configuration file to run the grid indicators",
                 "geoclimatedb": [
-                        "folder": folder.absolutePath,
+                        "folder": getDBFolderPath(),
                         "name"  : "geoclimate_chain_db;AUTO_SERVER=TRUE",
                         "delete": false
                 ],
@@ -352,7 +352,7 @@ abstract class WorkflowAbstractTest {
                         "folder"   : dataFolder,
                         "locations": [2000, 2001, 2002]],
                 "output"      : [
-                        "folder": ["path"  : folder.absolutePath,
+                        "folder": ["path"  : getDBFolderPath(),
                                    "tables": ["grid_indicators"]]],
                 "parameters"  :
                         ["distance"       : 0,
@@ -372,7 +372,7 @@ abstract class WorkflowAbstractTest {
         def bdTopoParameters = [
                 "description" : "Full workflow configuration file",
                 "geoclimatedb": [
-                        "folder": folder.absolutePath,
+                        "folder": getDBFolderPath(),
                         "name"  : "testFormatedData;AUTO_SERVER=TRUE",
                         "delete": true
                 ],
@@ -380,7 +380,7 @@ abstract class WorkflowAbstractTest {
                         "folder"   : dataFolder,
                         "locations": [getInseeCode()]],
                 "output"      : [
-                        "folder": ["path": folder.absolutePath]],
+                        "folder": ["path": getDBFolderPath()]],
                 "parameters"  :
                         ["distance": 0]
         ]
@@ -396,7 +396,7 @@ abstract class WorkflowAbstractTest {
         def bdTopoParameters = [
                 "description" : "Workflow format data",
                 "geoclimatedb": [
-                        "folder": folder.absolutePath,
+                        "folder": getDBFolderPath(),
                         "name"  : "testFormat;AUTO_SERVER=TRUE",
                         "delete": false
                 ],
@@ -404,7 +404,7 @@ abstract class WorkflowAbstractTest {
                         "folder"   : dataFolder,
                         "locations": [getInseeCode()]],
                 "output"      : [
-                        "folder": ["path": folder.absolutePath]]
+                        "folder": ["path": getDBFolderPath()]]
         ]
 
         Map process = BDTopo.workflow(bdTopoParameters, getVersion())
@@ -412,7 +412,7 @@ abstract class WorkflowAbstractTest {
 
         def tableNames = process[getInseeCode()]
         assertTrue(tableNames.size() > 0)
-        H2GIS h2gis = H2GIS.open(folder.absolutePath + File.separator + "testFormat;AUTO_SERVER=TRUE")
+        H2GIS h2gis = H2GIS.open(getDBFolderPath() + File.separator + "testFormat;AUTO_SERVER=TRUE")
 
         //Test zone
         assertTrue h2gis.firstRow("select count(*) as count from ${tableNames.zone} where the_geom is not null").count > 0

--- a/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/v2/WorkflowBDTopoV2Test.groovy
+++ b/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/v2/WorkflowBDTopoV2Test.groovy
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue
 class WorkflowBDTopoV2Test extends WorkflowAbstractTest {
 
     @TempDir(cleanup = CleanupMode.ON_SUCCESS)
-    static File folder
+    public static File folder
 
     @Override
     ArrayList getFileNames() {
@@ -45,6 +45,12 @@ class WorkflowBDTopoV2Test extends WorkflowAbstractTest {
     int getVersion() {
         return 2
     }
+
+    @Override
+    String getDBFolderPath(){
+        return folder.absolutePath
+    }
+
 
     @Override
     String getFolderName() {

--- a/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/v3/WorkflowBDTopoV3Test.groovy
+++ b/bdtopo/src/test/groovy/org/orbisgis/geoclimate/bdtopo/v3/WorkflowBDTopoV3Test.groovy
@@ -40,6 +40,11 @@ class WorkflowBDTopoV3Test extends WorkflowAbstractTest {
     }
 
     @Override
+    String getDBFolderPath() {
+        return folder.absolutePath
+    }
+
+    @Override
     String getFolderName() {
         return "sample_${getInseeCode()}"
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Simplify database url in config file. Use only the name of the database. e.g : h2://, postgis://
 - Add a test to check if the worldpop service is available
 - Fix github actions
+- Add TARGET landcover production

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -1241,8 +1241,9 @@ Map computeAllGeoIndicators(JdbcDataSource datasource, String zone, String build
         }
 
         indicatorUse = inputParameters.indicatorUse
-        //This is a shortcut to extract building with estimated height
-        if (indicatorUse.isEmpty()) {
+        //This is a shortcut to produce only the data
+        //TARGET indicators can be computed atthe grid scale with the input data
+        if (indicatorUse.isEmpty() || (indicatorUse.size()==1 && indicatorUse.contains("TARGET"))) {
             //Clean the System properties that stores intermediate table names
             datasource.dropTable(getCachedTableNames())
             clearTablesCache()


### PR DESCRIPTION
This PR adds a new option in the workflow to compute the landcover layer requiered to run the TARGET model (see https://github.com/jixuan-chen/target/tree/main)

The landcover layer is a regular grid saved by geoclimate in flatgeobuffer format as the grid_indicators layer.
By default the grid is computed on 100 x 100 resolution (meters) but the user can set a new resolution using the grid_indicators parameters. See the examples.

Enable the default target configuration

```groovy
"rsu_indicators": ["indicatorUse" : ["TARGET"]  ]
```

Customize the target grid size
```groovy
"rsu_indicators": ["indicatorUse" : ["TARGET"]],
"grid_indicators"   : [
                                "x_size"    : 200,
                                "y_size"    : 200
                        ]
```

@j3r3m1 