### PR TITLE
Count warm cells on a grid

### DIFF
--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
@@ -581,7 +581,9 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
                                                    "BUILDING_HEIGHT_DISTRIBUTION", "FRONTAL_AREA_INDEX", "SEA_LAND_FRACTION", "ASPECT_RATIO",
                                                    "SVF", "HEIGHT_OF_ROUGHNESS_ELEMENTS", "TERRAIN_ROUGHNESS_CLASS", "URBAN_SPRAWL_AREAS",
                                                    "URBAN_SPRAWL_DISTANCES", "URBAN_SPRAWL_COOL_DISTANCES", "STREET_WIDTH"]
-                    def allowedOutputIndicators = allowed_grid_indicators.intersect(list_indicators*.toUpperCase())
+                    def allowedOutputIndicators = list_indicators.findAll{
+                        it.startsWith("COUNT_WARN_") || allowed_grid_indicators.contains(it)
+                    }
                     if (allowedOutputIndicators) {
                         //Update the RSU indicators list according the grid indicators
                         list_indicators.each { val ->

--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
@@ -582,7 +582,7 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
                                                    "SVF", "HEIGHT_OF_ROUGHNESS_ELEMENTS", "TERRAIN_ROUGHNESS_CLASS", "URBAN_SPRAWL_AREAS",
                                                    "URBAN_SPRAWL_DISTANCES", "URBAN_SPRAWL_COOL_DISTANCES", "STREET_WIDTH"]
                     def allowedOutputIndicators = list_indicators.findAll{
-                        it.startsWith("COUNT_WARN_") || allowed_grid_indicators.contains(it)
+                        it.startsWith("COUNT_WARM_") || allowed_grid_indicators.contains(it)
                     }
                     if (allowedOutputIndicators) {
                         //Update the RSU indicators list according the grid indicators

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Add TARGET landcover production
 - Force TARGET ROOF fraction to 0.75 when BUILDING fraction is greater than 0.75
 - Force TARGET W indicator to the grid resolution
+- New grid indicator COUNT_WARN_X where X is the step of the sliding window

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,4 +11,4 @@
 - Force TARGET ROOF fraction to 0.75 when BUILDING fraction is greater than 0.75
 - Force TARGET W indicator to the grid resolution- 
 - Add lanes informations on abstract model plus OSM and BDTopo drivers
-- New grid indicator COUNT_WARN_X where X is the step of the sliding window
+- New grid indicator COUNT_WARM_X where X is the step of the sliding window

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/DataUtils.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/DataUtils.groovy
@@ -81,7 +81,7 @@ String joinTables(JdbcDataSource datasource, Map inputTableNamesWithId, String o
         ${indexes.toString()}
         CREATE TABLE $outputTableName AS SELECT $columnsAsString $leftQuery""")
         return outputTableName
-    } catch (java.sql.SQLException e) {
+    } catch (SQLException e) {
         throw new SQLException("Cannot join the tables", e)
     }
 }

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicators.groovy
@@ -414,3 +414,26 @@ String formatGrid4Target(JdbcDataSource datasource, String gridTable, float reso
         "Veg" VARCHAR, "dry" VARCHAR, "irr" VARCHAR , "H" VARCHAR, "W" VARCHAR)""")
     }
 }
+
+/**
+ *
+ * @author Erwan Bocher (CNRS)
+ */
+String gridWindows(JdbcDataSource datasource, String grid_indicators, String id_grid,def distance, int nb_levels = 1) throws Exception {
+
+    if (!grid_indicators) {
+        throw new IllegalArgumentException("No grid_indicators table to compute the statistics")
+    }
+
+    datasource.createIndex(grid_indicators, id_grid)
+
+    datasource.execute("""
+    UPDATE $grid_indicators SET count_warn =(
+            select avg(b.avg_ta) as num_neighbors from $grid_indicators a, $grid_indicators b
+    where st_dwithin(a.THE_GEOM, b.THE_GEOM, $distance) and a.$id_grid != b.$id_grid and a.$id_grid=mydata.$id_grid
+    group by a.$id_grid);
+
+    """)
+
+
+}

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicators.groovy
@@ -416,7 +416,7 @@ String formatGrid4Target(JdbcDataSource datasource, String gridTable, float reso
 }
 
 /**
- *  Compute the number of warn LCZ on a sliding window
+ *  Compute the number of warm LCZ on a sliding window
  *  The sliding window is defined by a step size from the center of the cells.
  *  The step size is an integer value defines the width and height (in terms of cells) of the window
  *  we are going to extract from an input grid
@@ -425,7 +425,7 @@ String formatGrid4Target(JdbcDataSource datasource, String gridTable, float reso
  *  @param  window_size array of window steps. User can specify multiple window steps.
  *  @author Erwan Bocher (CNRS)
  */
-String gridCountCellsWarn(JdbcDataSource datasource, String grid_indicators, List window_size) throws Exception {
+String gridCountCellsWarm(JdbcDataSource datasource, String grid_indicators, List window_size) throws Exception {
 
     if (!grid_indicators) {
         throw new IllegalArgumentException("No grid_indicators table to compute the statistics")
@@ -450,9 +450,9 @@ String gridCountCellsWarn(JdbcDataSource datasource, String grid_indicators, Lis
 
         def queries =[:]
         window_size.toSet().sort().each {size->
-          def table_size= postfix("warn_$size")
+          def table_size= postfix("warm_$size")
          queries.put(table_size, """DROP TABLE IF EXISTS ${table_size}; CREATE TABLE ${table_size} as select a.id_grid, COUNT(b.id_grid) as count_cells_${size},
-        sum(CASE WHEN  b.LCZ_PRIMARY in (1,2,3,4,5,6,7,8,9,10,105)  THEN 1 ELSE 0 END) as count_warn_${size}
+        sum(CASE WHEN  b.LCZ_PRIMARY in (1,2,3,4,5,6,7,8,9,10,105)  THEN 1 ELSE 0 END) as count_warm_${size}
         from ${grid_indicators}  a, ${grid_indicators} b
         where
         a.id_grid != b.id_grid and (b.id_row between a.id_row-${size} and a.id_row+${size})
@@ -469,6 +469,6 @@ String gridCountCellsWarn(JdbcDataSource datasource, String grid_indicators, Lis
         datasource.dropTable(tableToJoin.keySet().toList())
         return grid_final
     }catch (SQLException e) {
-        throw new SQLException("Cannot count the number of warn LCZ on a sliding window", e)
+        throw new SQLException("Cannot count the number of warm LCZ on a sliding window", e)
     }
 }

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicators.groovy
@@ -272,7 +272,7 @@ String multiscaleLCZGrid(JdbcDataSource datasource, String grid_indicators, Stri
         }
         return tableLevelToJoin
     } catch (SQLException e) {
-        throw new SQLException("", e)
+        throw new SQLException("Cannot aggregate the LCZ_PRIMARY indicators to new grid levels", e)
     } finally {
         datasource.dropTable(tablesToDrop)
     }
@@ -416,24 +416,59 @@ String formatGrid4Target(JdbcDataSource datasource, String gridTable, float reso
 }
 
 /**
- *
- * @author Erwan Bocher (CNRS)
+ *  Compute the number of warn LCZ on a sliding window
+ *  The sliding window is defined by a step size from the center of the cells.
+ *  The step size is an integer value defines the width and height (in terms of cells) of the window
+ *  we are going to extract from an input grid
+ *  @param datasource connection to the database
+ *  @param grid_indicators input grid
+ *  @param  window_size array of window steps. User can specify multiple window steps.
+ *  @author Erwan Bocher (CNRS)
  */
-String gridWindows(JdbcDataSource datasource, String grid_indicators, String id_grid,def distance, int nb_levels = 1) throws Exception {
+String gridCountCellsWarn(JdbcDataSource datasource, String grid_indicators, List window_size) throws Exception {
 
     if (!grid_indicators) {
         throw new IllegalArgumentException("No grid_indicators table to compute the statistics")
     }
 
-    datasource.createIndex(grid_indicators, id_grid)
-
-    datasource.execute("""
-    UPDATE $grid_indicators SET count_warn =(
-            select avg(b.avg_ta) as num_neighbors from $grid_indicators a, $grid_indicators b
-    where st_dwithin(a.THE_GEOM, b.THE_GEOM, $distance) and a.$id_grid != b.$id_grid and a.$id_grid=mydata.$id_grid
-    group by a.$id_grid);
-
-    """)
+    if(!window_size){
+        throw new IllegalArgumentException("Please provide at least one window size")
+    }
 
 
+    if(window_size.min()<1){
+        throw new IllegalArgumentException("The window sizes must be greater or equal than 1 cell")
+    }
+
+    if(window_size.max()>=10){
+        throw new IllegalArgumentException("The window sizes must be less or equal than 100 cells")
+    }
+    try {
+        datasource.createIndex(grid_indicators, "id_grid")
+        datasource.createIndex(grid_indicators, "id_row")
+        datasource.createIndex(grid_indicators, "id_col")
+
+        def queries =[:]
+        window_size.toSet().sort().each {size->
+          def table_size= postfix("warn_$size")
+         queries.put(table_size, """DROP TABLE IF EXISTS ${table_size}; CREATE TABLE ${table_size} as select a.id_grid, COUNT(b.id_grid) as count_cells_${size},
+        sum(CASE WHEN  b.LCZ_PRIMARY in (1,2,3,4,5,6,7,8,9,10,105)  THEN 1 ELSE 0 END) as count_warn_${size}
+        from ${grid_indicators}  a, ${grid_indicators} b
+        where
+        a.id_grid != b.id_grid and (b.id_row between a.id_row-${size} and a.id_row+${size})
+        and (b.id_col between a.id_col-${size} and a.id_col+${size})
+        group by a.id_grid;""")
+        }
+        datasource.execute(queries.values().join("\n"))
+        def grid_final = postfix("grid_indicators")
+        def tableToJoin =[:]
+        queries.keySet().each {it->
+            tableToJoin.put(it,"id_grid")
+        }
+        Geoindicators.DataUtils.joinTables(datasource, tableToJoin, grid_final)
+        datasource.dropTable(tableToJoin.keySet().toList())
+        return grid_final
+    }catch (SQLException e) {
+        throw new SQLException("Cannot count the number of warn LCZ on a sliding window", e)
+    }
 }

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -1593,6 +1593,16 @@ String rasterizeIndicators(JdbcDataSource datasource,
     def grid_column_identifier = "id_grid"
     def indicatorTablesToJoin = [:]
     indicatorTablesToJoin.put(grid, grid_column_identifier)
+
+    //We check if the COUNT_WARN indicators must be computed.
+    //If yes we collect all window sizes
+    def window_sizes=[]
+    list_indicators_upper.each{
+        if(it.startsWith("COUNT_WARN_")){
+            window_sizes<< Integer.valueOf(it.substring(11, it.length()))
+        }
+    }
+
     // Needed for intermediate calculations...
     def tablesToJoinForWidth = [:]
 
@@ -1601,17 +1611,17 @@ String rasterizeIndicators(JdbcDataSource datasource,
     /*
     * Make aggregation process with previous grid and current rsu lcz
     */
-    if (list_indicators_upper.intersect(["LCZ_FRACTION", "LCZ_PRIMARY", "URBAN_SPRAWL_AREAS", "URBAN_SPRAWL_DISTANCES", "URBAN_SPRAWL_COOL_DISTANCES"]) && rsu_lcz) {
+    if ((list_indicators_upper.intersect(["LCZ_FRACTION", "LCZ_PRIMARY", "URBAN_SPRAWL_AREAS", "URBAN_SPRAWL_DISTANCES", "URBAN_SPRAWL_COOL_DISTANCES"])|| window_sizes) && rsu_lcz)  {
         def indicatorName = "LCZ_PRIMARY"
-        String upperScaleAreaStatistics = Geoindicators.GenericIndicators.upperScaleAreaStatistics(
+        String lczUpperScaleAreaStatistics = Geoindicators.GenericIndicators.upperScaleAreaStatistics(
                 datasource, grid, grid_column_identifier,
                 rsu_lcz, indicatorName, indicatorName,
                 false, "lcz")
-        if (upperScaleAreaStatistics) {
-            indicatorTablesToJoin.put(upperScaleAreaStatistics, grid_column_identifier)
+        if (lczUpperScaleAreaStatistics) {
+            indicatorTablesToJoin.put(lczUpperScaleAreaStatistics, grid_column_identifier)
             if (list_indicators_upper.contains("LCZ_PRIMARY")) {
                 def resultsDistrib = Geoindicators.GenericIndicators.distributionCharacterization(datasource,
-                        upperScaleAreaStatistics, upperScaleAreaStatistics, grid_column_identifier,
+                        lczUpperScaleAreaStatistics, lczUpperScaleAreaStatistics, grid_column_identifier,
                         ["equality", "uniqueness"],
                         "GREATEST", true, true,
                         "lcz")
@@ -1639,17 +1649,28 @@ String rasterizeIndicators(JdbcDataSource datasource,
                 }
                 def distribLczTableInt = postfix "distribLczTableInt"
 
-                datasource """  DROP TABLE IF EXISTS $distribLczTableInt;
+                datasource.execute("""  DROP TABLE IF EXISTS $distribLczTableInt;
                                 CREATE TABLE $distribLczTableInt
                                         AS SELECT   $grid_column_identifier, $casewhenQuery1 null$parenthesis AS LCZ_PRIMARY,
                                                     $casewhenQuery2 null$parenthesis AS LCZ_SECONDARY, 
                                                     MIN_DISTANCE, LCZ_UNIQUENESS_VALUE, LCZ_EQUALITY_VALUE 
                                         FROM $resultsDistrib;
-                                DROP TABLE IF EXISTS $resultsDistrib""".toString()
+                                DROP TABLE IF EXISTS $resultsDistrib""")
                 tablesToDrop << resultsDistrib
                 indicatorTablesToJoin.put(distribLczTableInt, grid_column_identifier)
+                //We compute COUNT_WARN indicators
+                if(window_sizes){
+                    String grid_lcz_primary_indexes =  postfix("grid_lcz_indexes")
+                    datasource.createIndex(distribLczTableInt, grid_column_identifier)
+                    datasource.execute("""DROP TABLE IF EXISTS ${grid_lcz_primary_indexes};
+                    CREATE TABLE $grid_lcz_primary_indexes as 
+                    select a.$grid_column_identifier, a.id_row, a.id_col, b.LCZ_PRIMARY FROM
+                    $grid as a left join $distribLczTableInt as b on a.$grid_column_identifier=b.$grid_column_identifier;""")
+                    String grid_count_warn = Geoindicators.GridIndicators.gridCountCellsWarn(datasource, grid_lcz_primary_indexes, window_sizes)
+                    indicatorTablesToJoin.put(grid_count_warn, grid_column_identifier)
+                    tablesToDrop<<grid_lcz_primary_indexes
+                }
             }
-
         } else {
             info "Cannot aggregate the LCZ at grid scale"
         }
@@ -1974,7 +1995,7 @@ String rasterizeIndicators(JdbcDataSource datasource,
     }
 
     //Join all indicators at grid scale
-    def joinGrids = Geoindicators.DataUtils.joinTables(datasource, indicatorTablesToJoin, grid_indicators_table)
+    Geoindicators.DataUtils.joinTables(datasource, indicatorTablesToJoin, grid_indicators_table)
 
     //Execute commands
     datasource.execute(sqlUpdateCommand.join(" "))
@@ -1989,6 +2010,8 @@ String rasterizeIndicators(JdbcDataSource datasource,
 
     return grid_indicators_table
 }
+
+
 
 /**
  * Method to cut the building with a grid or any other table

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicators.groovy
@@ -1594,11 +1594,11 @@ String rasterizeIndicators(JdbcDataSource datasource,
     def indicatorTablesToJoin = [:]
     indicatorTablesToJoin.put(grid, grid_column_identifier)
 
-    //We check if the COUNT_WARN indicators must be computed.
+    //We check if the COUNT_WARM indicators must be computed.
     //If yes we collect all window sizes
     def window_sizes=[]
     list_indicators_upper.each{
-        if(it.startsWith("COUNT_WARN_")){
+        if(it.startsWith("COUNT_WARM_")){
             window_sizes<< Integer.valueOf(it.substring(11, it.length()))
         }
     }
@@ -1658,7 +1658,7 @@ String rasterizeIndicators(JdbcDataSource datasource,
                                 DROP TABLE IF EXISTS $resultsDistrib""")
                 tablesToDrop << resultsDistrib
                 indicatorTablesToJoin.put(distribLczTableInt, grid_column_identifier)
-                //We compute COUNT_WARN indicators
+                //We compute COUNT_WARM indicators
                 if(window_sizes){
                     String grid_lcz_primary_indexes =  postfix("grid_lcz_indexes")
                     datasource.createIndex(distribLczTableInt, grid_column_identifier)
@@ -1666,8 +1666,8 @@ String rasterizeIndicators(JdbcDataSource datasource,
                     CREATE TABLE $grid_lcz_primary_indexes as 
                     select a.$grid_column_identifier, a.id_row, a.id_col, b.LCZ_PRIMARY FROM
                     $grid as a left join $distribLczTableInt as b on a.$grid_column_identifier=b.$grid_column_identifier;""")
-                    String grid_count_warn = Geoindicators.GridIndicators.gridCountCellsWarn(datasource, grid_lcz_primary_indexes, window_sizes)
-                    indicatorTablesToJoin.put(grid_count_warn, grid_column_identifier)
+                    String grid_count_warm = Geoindicators.GridIndicators.gridCountCellsWarm(datasource, grid_lcz_primary_indexes, window_sizes)
+                    indicatorTablesToJoin.put(grid_count_warm, grid_column_identifier)
                     tablesToDrop<<grid_lcz_primary_indexes
                 }
             }

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicatorsTests.groovy
@@ -121,4 +121,19 @@ class GridIndicatorsTests {
         String grid_distances = Geoindicators.GridIndicators.gridDistances(h2GIS, "polygons", "grid", "id")
         assertEquals(12, h2GIS.firstRow("select count(*) as count from $grid_distances where distance =0.5".toString()).count)
     }
+
+    @Test
+    void gridDistanceStats() {
+        h2GIS.execute("""
+        --Grid with random values between 1 and 5 (Urban LCZ)
+        DROP TABLE IF EXISTS grid;
+        CREATE TABLE grid AS SELECT  * EXCEPT(ID), id as id_grid, (CAST 3 AS INTEGER) AS lcz_primary FROM 
+        ST_MakeGrid('POLYGON((0 0, 9 0, 9 9, 0 0))'::GEOMETRY, 1, 1);
+        --Add some cool LCZ
+        
+        """)
+
+        h2GIS.save("grid", "/tmp/grid.fgb", true)
+
+    }
 }

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicatorsTests.groovy
@@ -10,6 +10,7 @@ import org.orbisgis.geoclimate.Geoindicators
 
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.orbisgis.data.H2GIS.open
 
 class GridIndicatorsTests {
@@ -60,13 +61,13 @@ class GridIndicatorsTests {
 
         def expectedValues = [ID_COL: 2, ID_ROW: 2, ID_GRID: 10, LCZ_PRIMARY: 2, LCZ_PRIMARY_N: 104, LCZ_PRIMARY_NE: 104, LCZ_PRIMARY_E: 104, LCZ_PRIMARY_SE: 104, LCZ_PRIMARY_S: 104, LCZ_PRIMARY_SW: 104, LCZ_PRIMARY_W: 104, LCZ_PRIMARY_NW: 104, LCZ_WARM: 1, ID_ROW_LOD_1: 1, ID_COL_LOD_1: 0, LCZ_WARM_LOD_1: 1, LCZ_COOL_LOD_1: 8, LCZ_PRIMARY_LOD_1: 104, LCZ_PRIMARY_N_LOD_1: 104, LCZ_PRIMARY_NE_LOD_1: 2, LCZ_PRIMARY_E_LOD_1: 104, LCZ_PRIMARY_SE_LOD_1: null, LCZ_PRIMARY_S_LOD_1: null, LCZ_PRIMARY_SW_LOD_1: null, LCZ_PRIMARY_W_LOD_1: null, LCZ_PRIMARY_NW_LOD_1: null, LCZ_WARM_N_LOD_1: null, LCZ_WARM_NE_LOD_1: 4, LCZ_WARM_E_LOD_1: null, LCZ_WARM_SE_LOD_1: null, LCZ_WARM_S_LOD_1: null, LCZ_WARM_SW_LOD_1: null, LCZ_WARM_W_LOD_1: null, LCZ_WARM_NW_LOD_1: null, ID_ROW_LOD_2: 1, ID_COL_LOD_2: 1, LCZ_WARM_LOD_2: 10, LCZ_COOL_LOD_2: 71, LCZ_PRIMARY_LOD_2: 104, LCZ_PRIMARY_N_LOD_2: null, LCZ_PRIMARY_NE_LOD_2: null, LCZ_PRIMARY_E_LOD_2: null, LCZ_PRIMARY_SE_LOD_2: null, LCZ_PRIMARY_S_LOD_2: null, LCZ_PRIMARY_SW_LOD_2: null, LCZ_PRIMARY_W_LOD_2: null, LCZ_PRIMARY_NW_LOD_2: null, LCZ_WARM_N_LOD_2: null, LCZ_WARM_NE_LOD_2: null, LCZ_WARM_E_LOD_2: null, LCZ_WARM_SE_LOD_2: null, LCZ_WARM_S_LOD_2: null, LCZ_WARM_SW_LOD_2: null, LCZ_WARM_W_LOD_2: null, LCZ_WARM_NW_LOD_2: null]
 
-        assertEquals(values , expectedValues)
+        assertTrue(values == expectedValues)
 
         values = h2GIS.firstRow("SELECT * EXCEPT(THE_GEOM) FROM $grid_scale  WHERE id_row = 5 AND id_col = 5 ".toString())
 
         expectedValues = [ID_COL: 5, ID_ROW: 5, ID_GRID: 40, LCZ_PRIMARY: 102, LCZ_PRIMARY_N: 2, LCZ_PRIMARY_NE: 2, LCZ_PRIMARY_E: 2, LCZ_PRIMARY_SE: 104, LCZ_PRIMARY_S: 104, LCZ_PRIMARY_SW: 104, LCZ_PRIMARY_W: 104, LCZ_PRIMARY_NW: 2, LCZ_WARM: 4, ID_ROW_LOD_1: 2, ID_COL_LOD_1: 1, LCZ_WARM_LOD_1: 4, LCZ_COOL_LOD_1: 5, LCZ_PRIMARY_LOD_1: 2, LCZ_PRIMARY_N_LOD_1: 104, LCZ_PRIMARY_NE_LOD_1: 2, LCZ_PRIMARY_E_LOD_1: 104, LCZ_PRIMARY_SE_LOD_1: 104, LCZ_PRIMARY_S_LOD_1: 104, LCZ_PRIMARY_SW_LOD_1: 104, LCZ_PRIMARY_W_LOD_1: 104, LCZ_PRIMARY_NW_LOD_1: 104, LCZ_WARM_N_LOD_1: null, LCZ_WARM_NE_LOD_1: 5, LCZ_WARM_E_LOD_1: null, LCZ_WARM_SE_LOD_1: null, LCZ_WARM_S_LOD_1: null, LCZ_WARM_SW_LOD_1: 1, LCZ_WARM_W_LOD_1: null, LCZ_WARM_NW_LOD_1: null, ID_ROW_LOD_2: 1, ID_COL_LOD_2: 1, LCZ_WARM_LOD_2: 10, LCZ_COOL_LOD_2: 71, LCZ_PRIMARY_LOD_2: 104, LCZ_PRIMARY_N_LOD_2: null, LCZ_PRIMARY_NE_LOD_2: null, LCZ_PRIMARY_E_LOD_2: null, LCZ_PRIMARY_SE_LOD_2: null, LCZ_PRIMARY_S_LOD_2: null, LCZ_PRIMARY_SW_LOD_2: null, LCZ_PRIMARY_W_LOD_2: null, LCZ_PRIMARY_NW_LOD_2: null, LCZ_WARM_N_LOD_2: null, LCZ_WARM_NE_LOD_2: null, LCZ_WARM_E_LOD_2: null, LCZ_WARM_SE_LOD_2: null, LCZ_WARM_S_LOD_2: null, LCZ_WARM_SW_LOD_2: null, LCZ_WARM_W_LOD_2: null, LCZ_WARM_NW_LOD_2: null]
 
-        assertEquals(values , expectedValues)
+        assertTrue(values == expectedValues)
 
         h2GIS.dropTable("grid")
     }

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicatorsTests.groovy
@@ -124,7 +124,7 @@ class GridIndicatorsTests {
     }
 
     @Test
-    void gridCountCellsWarnTest1() {
+    void gridCountCellsWarmTest1() {
         h2GIS.execute("""
         --Grid with random values between 1 and 5 (Urban LCZ)
         DROP TABLE IF EXISTS grid;
@@ -136,27 +136,27 @@ class GridIndicatorsTests {
         UPDATE grid SET lcz_primary= 102 WHERE id_row>3 and id_row<6 AND id_col>3 and id_col<6;
         """)
         h2GIS.save("grid", "/tmp/grid.fgb", true)
-        String grid_stats = Geoindicators.GridIndicators.gridCountCellsWarn(h2GIS, "grid", [1])
+        String grid_stats = Geoindicators.GridIndicators.gridCountCellsWarm(h2GIS, "grid", [1])
 
-        def expectedValues = [72: [count_cells_1: 3, count_warn_1: 3],
-                              40: [count_cells_1: 8, count_warn_1: 5],
-                              1: [count_cells_1: 5, count_warn_1: 4]]
+        def expectedValues = [72: [count_cells_1: 3, count_warm_1: 3],
+                              40: [count_cells_1: 8, count_warm_1: 5],
+                              1: [count_cells_1: 5, count_warm_1: 4]]
 
         expectedValues.each { it ->
             def values = it.value
-            def valuesRes = h2GIS.rows("SELECT count_cells_1, count_warn_1 from $grid_stats where id_grid = ${it.key}")
+            def valuesRes = h2GIS.rows("SELECT count_cells_1, count_warm_1 from $grid_stats where id_grid = ${it.key}")
             assertEquals(values.count_cells_1, valuesRes.count_cells_1[0])
-            assertEquals(values.count_warn_1, valuesRes.count_warn_1[0])
+            assertEquals(values.count_warm_1, valuesRes.count_warm_1[0])
         }
     }
 
     @Test
-    void gridCountCellsWarnTest2() {
-        assertThrows(Exception.class, () -> Geoindicators.GridIndicators.gridCountCellsWarn(h2GIS, "grid", [-1, 2, 3, 4]))
+    void gridCountCellsWarmTest2() {
+        assertThrows(Exception.class, () -> Geoindicators.GridIndicators.gridCountCellsWarm(h2GIS, "grid", [-1, 2, 3, 4]))
     }
 
     @Test
-    void gridCountCellsWarnTest3() {
-        assertThrows(Exception.class, () -> Geoindicators.GridIndicators.gridCountCellsWarn(h2GIS, "grid", [5, 2, 3, 50]))
+    void gridCountCellsWarmTest3() {
+        assertThrows(Exception.class, () -> Geoindicators.GridIndicators.gridCountCellsWarm(h2GIS, "grid", [5, 2, 3, 50]))
     }
 }

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicatorsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/GridIndicatorsTests.groovy
@@ -9,7 +9,7 @@ import org.orbisgis.data.H2GIS
 import org.orbisgis.geoclimate.Geoindicators
 
 import static org.junit.jupiter.api.Assertions.assertEquals
-import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.orbisgis.data.H2GIS.open
 
 class GridIndicatorsTests {
@@ -60,13 +60,13 @@ class GridIndicatorsTests {
 
         def expectedValues = [ID_COL: 2, ID_ROW: 2, ID_GRID: 10, LCZ_PRIMARY: 2, LCZ_PRIMARY_N: 104, LCZ_PRIMARY_NE: 104, LCZ_PRIMARY_E: 104, LCZ_PRIMARY_SE: 104, LCZ_PRIMARY_S: 104, LCZ_PRIMARY_SW: 104, LCZ_PRIMARY_W: 104, LCZ_PRIMARY_NW: 104, LCZ_WARM: 1, ID_ROW_LOD_1: 1, ID_COL_LOD_1: 0, LCZ_WARM_LOD_1: 1, LCZ_COOL_LOD_1: 8, LCZ_PRIMARY_LOD_1: 104, LCZ_PRIMARY_N_LOD_1: 104, LCZ_PRIMARY_NE_LOD_1: 2, LCZ_PRIMARY_E_LOD_1: 104, LCZ_PRIMARY_SE_LOD_1: null, LCZ_PRIMARY_S_LOD_1: null, LCZ_PRIMARY_SW_LOD_1: null, LCZ_PRIMARY_W_LOD_1: null, LCZ_PRIMARY_NW_LOD_1: null, LCZ_WARM_N_LOD_1: null, LCZ_WARM_NE_LOD_1: 4, LCZ_WARM_E_LOD_1: null, LCZ_WARM_SE_LOD_1: null, LCZ_WARM_S_LOD_1: null, LCZ_WARM_SW_LOD_1: null, LCZ_WARM_W_LOD_1: null, LCZ_WARM_NW_LOD_1: null, ID_ROW_LOD_2: 1, ID_COL_LOD_2: 1, LCZ_WARM_LOD_2: 10, LCZ_COOL_LOD_2: 71, LCZ_PRIMARY_LOD_2: 104, LCZ_PRIMARY_N_LOD_2: null, LCZ_PRIMARY_NE_LOD_2: null, LCZ_PRIMARY_E_LOD_2: null, LCZ_PRIMARY_SE_LOD_2: null, LCZ_PRIMARY_S_LOD_2: null, LCZ_PRIMARY_SW_LOD_2: null, LCZ_PRIMARY_W_LOD_2: null, LCZ_PRIMARY_NW_LOD_2: null, LCZ_WARM_N_LOD_2: null, LCZ_WARM_NE_LOD_2: null, LCZ_WARM_E_LOD_2: null, LCZ_WARM_SE_LOD_2: null, LCZ_WARM_S_LOD_2: null, LCZ_WARM_SW_LOD_2: null, LCZ_WARM_W_LOD_2: null, LCZ_WARM_NW_LOD_2: null]
 
-        assertTrue(values == expectedValues)
+        assertEquals(values , expectedValues)
 
         values = h2GIS.firstRow("SELECT * EXCEPT(THE_GEOM) FROM $grid_scale  WHERE id_row = 5 AND id_col = 5 ".toString())
 
         expectedValues = [ID_COL: 5, ID_ROW: 5, ID_GRID: 40, LCZ_PRIMARY: 102, LCZ_PRIMARY_N: 2, LCZ_PRIMARY_NE: 2, LCZ_PRIMARY_E: 2, LCZ_PRIMARY_SE: 104, LCZ_PRIMARY_S: 104, LCZ_PRIMARY_SW: 104, LCZ_PRIMARY_W: 104, LCZ_PRIMARY_NW: 2, LCZ_WARM: 4, ID_ROW_LOD_1: 2, ID_COL_LOD_1: 1, LCZ_WARM_LOD_1: 4, LCZ_COOL_LOD_1: 5, LCZ_PRIMARY_LOD_1: 2, LCZ_PRIMARY_N_LOD_1: 104, LCZ_PRIMARY_NE_LOD_1: 2, LCZ_PRIMARY_E_LOD_1: 104, LCZ_PRIMARY_SE_LOD_1: 104, LCZ_PRIMARY_S_LOD_1: 104, LCZ_PRIMARY_SW_LOD_1: 104, LCZ_PRIMARY_W_LOD_1: 104, LCZ_PRIMARY_NW_LOD_1: 104, LCZ_WARM_N_LOD_1: null, LCZ_WARM_NE_LOD_1: 5, LCZ_WARM_E_LOD_1: null, LCZ_WARM_SE_LOD_1: null, LCZ_WARM_S_LOD_1: null, LCZ_WARM_SW_LOD_1: 1, LCZ_WARM_W_LOD_1: null, LCZ_WARM_NW_LOD_1: null, ID_ROW_LOD_2: 1, ID_COL_LOD_2: 1, LCZ_WARM_LOD_2: 10, LCZ_COOL_LOD_2: 71, LCZ_PRIMARY_LOD_2: 104, LCZ_PRIMARY_N_LOD_2: null, LCZ_PRIMARY_NE_LOD_2: null, LCZ_PRIMARY_E_LOD_2: null, LCZ_PRIMARY_SE_LOD_2: null, LCZ_PRIMARY_S_LOD_2: null, LCZ_PRIMARY_SW_LOD_2: null, LCZ_PRIMARY_W_LOD_2: null, LCZ_PRIMARY_NW_LOD_2: null, LCZ_WARM_N_LOD_2: null, LCZ_WARM_NE_LOD_2: null, LCZ_WARM_E_LOD_2: null, LCZ_WARM_SE_LOD_2: null, LCZ_WARM_S_LOD_2: null, LCZ_WARM_SW_LOD_2: null, LCZ_WARM_W_LOD_2: null, LCZ_WARM_NW_LOD_2: null]
 
-        assertTrue(values == expectedValues)
+        assertEquals(values , expectedValues)
 
         h2GIS.dropTable("grid")
     }
@@ -123,17 +123,39 @@ class GridIndicatorsTests {
     }
 
     @Test
-    void gridDistanceStats() {
+    void gridCountCellsWarnTest1() {
         h2GIS.execute("""
         --Grid with random values between 1 and 5 (Urban LCZ)
         DROP TABLE IF EXISTS grid;
-        CREATE TABLE grid AS SELECT  * EXCEPT(ID), id as id_grid, (CAST 3 AS INTEGER) AS lcz_primary FROM 
+        CREATE TABLE grid AS SELECT  * EXCEPT(ID), id as id_grid, CEIL(RANDOM() * 10) AS lcz_primary FROM 
         ST_MakeGrid('POLYGON((0 0, 9 0, 9 9, 0 0))'::GEOMETRY, 1, 1);
-        --Add some cool LCZ
         
+        --Add some vegetation cells
+        UPDATE grid SET lcz_primary= 102 WHERE id_row = 2 AND id_col = 2;
+        UPDATE grid SET lcz_primary= 102 WHERE id_row>3 and id_row<6 AND id_col>3 and id_col<6;
         """)
-
         h2GIS.save("grid", "/tmp/grid.fgb", true)
+        String grid_stats = Geoindicators.GridIndicators.gridCountCellsWarn(h2GIS, "grid", [1])
 
+        def expectedValues = [72: [count_cells_1: 3, count_warn_1: 3],
+                              40: [count_cells_1: 8, count_warn_1: 5],
+                              1: [count_cells_1: 5, count_warn_1: 4]]
+
+        expectedValues.each { it ->
+            def values = it.value
+            def valuesRes = h2GIS.rows("SELECT count_cells_1, count_warn_1 from $grid_stats where id_grid = ${it.key}")
+            assertEquals(values.count_cells_1, valuesRes.count_cells_1[0])
+            assertEquals(values.count_warn_1, valuesRes.count_warn_1[0])
+        }
+    }
+
+    @Test
+    void gridCountCellsWarnTest2() {
+        assertThrows(Exception.class, () -> Geoindicators.GridIndicators.gridCountCellsWarn(h2GIS, "grid", [-1, 2, 3, 4]))
+    }
+
+    @Test
+    void gridCountCellsWarnTest3() {
+        assertThrows(Exception.class, () -> Geoindicators.GridIndicators.gridCountCellsWarn(h2GIS, "grid", [5, 2, 3, 50]))
     }
 }

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -902,7 +902,10 @@ def extractProcessingParameters(def processing_parameters) throws Exception {
                                                "FRONTAL_AREA_INDEX", "SEA_LAND_FRACTION", "ASPECT_RATIO", "SVF",
                                                "HEIGHT_OF_ROUGHNESS_ELEMENTS", "TERRAIN_ROUGHNESS_CLASS", "URBAN_SPRAWL_AREAS",
                                                "URBAN_SPRAWL_DISTANCES", "URBAN_SPRAWL_COOL_DISTANCES","STREET_WIDTH"]
-                def allowedOutputIndicators = allowed_grid_indicators.intersect(list_indicators*.toUpperCase())
+                def allowedOutputIndicators = list_indicators.findAll{
+                    it.startsWith("COUNT_WARN_") || allowed_grid_indicators.contains(it)
+                }
+
                 if (allowedOutputIndicators) {
                     //Update the RSU indicators list according the grid indicators
                     list_indicators.each { val ->

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -903,7 +903,7 @@ def extractProcessingParameters(def processing_parameters) throws Exception {
                                                "HEIGHT_OF_ROUGHNESS_ELEMENTS", "TERRAIN_ROUGHNESS_CLASS", "URBAN_SPRAWL_AREAS",
                                                "URBAN_SPRAWL_DISTANCES", "URBAN_SPRAWL_COOL_DISTANCES","STREET_WIDTH"]
                 def allowedOutputIndicators = list_indicators.findAll{
-                    it.startsWith("COUNT_WARN_") || allowed_grid_indicators.contains(it)
+                    it.startsWith("COUNT_WARM_") || allowed_grid_indicators.contains(it)
                 }
 
                 if (allowedOutputIndicators) {

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -719,12 +719,12 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
-        def location = "Nantes"
+        def location = "Redon"
         def nominatim = OSMTools.Utilities.getNominatimData(location)
-        def grid_size = 100
-        location =[47.214976592711274,-1.6425595375815742,47.25814872718718,-1.5659501122281323]
+        def grid_size = 500
+        //location =[47.214976592711274,-1.6425595375815742,47.25814872718718,-1.5659501122281323]
         //location=[47.215334,-1.558058,47.216646,-1.556185]
-        location = nominatim.bbox
+        //location = nominatim.bbox
         //location=[51.2, 1.0, 51.4, 1.2]
         /* location =[ 48.84017284026897,
                     2.3061887733275785,
@@ -759,7 +759,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                 "parameters"  :
                         ["distance"             : 0,
                          "rsu_indicators"       : [
-                                 "indicatorUse": ["TARGET"] //, "UTRF"]
+                                 "indicatorUse": ["LCZ"] //, "UTRF"]
 
                          ], "grid_indicators"   : [
                                 "x_size"    : grid_size,
@@ -779,7 +779,8 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                                         "ASPECT_RATIO",
                                         //"SVF",
                                         "STREET_WIDTH" ,
-                                        "IMPERVIOUS_FRACTION"]
+                                        "IMPERVIOUS_FRACTION",
+                                        "COUNT_WARN_1"]
                                 //"lcz_lod":1
                         ], "worldpop_indicators": true
                          /*

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -780,8 +780,8 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                                         //"SVF",
                                         "STREET_WIDTH" ,
                                         "IMPERVIOUS_FRACTION",
-                                        "COUNT_WARN_1",
-                                        "COUNT_WARN_4"]
+                                        "COUNT_WARM_1",
+                                        "COUNT_WARM_4"]
                                 //"lcz_lod":1
                         ], "worldpop_indicators": true
                          /*

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -719,12 +719,12 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         File dirFile = new File(directory)
         dirFile.delete()
         dirFile.mkdir()
-        def location = "Redon"
+        def location = "Lorient"
         def nominatim = OSMTools.Utilities.getNominatimData(location)
-        def grid_size = 500
+        def grid_size = 100
         //location =[47.214976592711274,-1.6425595375815742,47.25814872718718,-1.5659501122281323]
         //location=[47.215334,-1.558058,47.216646,-1.556185]
-        //location = nominatim.bbox
+        location = nominatim.bbox
         //location=[51.2, 1.0, 51.4, 1.2]
         /* location =[ 48.84017284026897,
                     2.3061887733275785,
@@ -757,7 +757,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                                          "zone"                   : "zone"]]]*/
                 ,
                 "parameters"  :
-                        ["distance"             : 0,
+                        ["distance"             : 500,
                          "rsu_indicators"       : [
                                  "indicatorUse": ["LCZ"] //, "UTRF"]
 
@@ -780,7 +780,8 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                                         //"SVF",
                                         "STREET_WIDTH" ,
                                         "IMPERVIOUS_FRACTION",
-                                        "COUNT_WARN_1"]
+                                        "COUNT_WARN_1",
+                                        "COUNT_WARN_4"]
                                 //"lcz_lod":1
                         ], "worldpop_indicators": true
                          /*


### PR DESCRIPTION
This PR introduces a new indicator to count the number of warm cells using a sliding window.

For example, if the user wants to count the number of hot cells in a 3*3 window, it must add the COUNT_WARM_1 term to the list of grid indicators.

The number 1 corresponds to the cell offset from the center of the processed cell.
The user can add several window sizes like this :  COUNT_WARM_1 , COUNT_WARM_2, COUNT_WARM_5.

**Input LCZ grid**

![grid_220_lcz_lorient](https://github.com/user-attachments/assets/b0d4fee0-79a8-483a-93fa-5a4198547e21)

**Number of warn cells (COUNT_WARM_1)**
![grid_250_lcz_lorient_warn_1](https://github.com/user-attachments/assets/1d3235f3-b51d-46cd-8496-38951e5dbc09)

**Number of warn cells (COUNT_WARM_4)**
![grid_250_lcz_lorient_warn_4](https://github.com/user-attachments/assets/e3fa0429-6f5d-4f43-b524-bcea7f808bd1)

**Config file input**
  ```json
              "parameters"  :
                        ["distance"             : 500,
                         "rsu_indicators"       : [
                                 "indicatorUse": ["LCZ"] 

                         ], "grid_indicators"   : [
                                "x_size"    : 100,
                                "y_size"    : 100,
                                "indicators": [
                                        "LCZ_PRIMARY",
                                        "COUNT_WARM_1",
                                        "COUNT_WARM_4"]
                        ],...
```

@MGousseff  @j3r3m1 
