### PR TITLE
Improve RSU segmentation plus new OSM tag analysis

### DIFF
--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/AbstractBDTopoWorkflow.groovy
@@ -446,7 +446,7 @@ abstract class AbstractBDTopoWorkflow extends BDTopoUtils {
                                       svfSimplified      : true,
                                       surface_vegetation : 10000f,
                                       surface_hydro      : 2500f,
-                                      surface_urban_areas: 10000f,
+                                      surface_urban_areas: 10f,
                                       snappingTolerance  : 0.01f,
                                       mapOfWeights       : ["sky_view_factor"             : 4,
                                                             "aspect_ratio"                : 3,

--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/BDTopoV2Workflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/BDTopoV2Workflow.groovy
@@ -375,7 +375,7 @@ def filterLinkedShapeFiles(def location, float distance, LinkedHashMap inputTabl
             //Extract surface_eau
             debug "Loading in the H2GIS database $outputTableName"
             outputTableName = "SURFACE_EAU"
-            h2gis_datasource.execute("DROP TABLE IF EXISTS $outputTableName ; CREATE TABLE $outputTableName as SELECT ID, $formatting_geom , NATURE FROM ${inputTables.surface_eau}  WHERE the_geom && 'SRID=$sourceSRID;$geomToExtract'::GEOMETRY AND ST_INTERSECTS(the_geom, 'SRID=$sourceSRID;$geomToExtract'::GEOMETRY)".toString())
+            h2gis_datasource.execute("DROP TABLE IF EXISTS $outputTableName ; CREATE TABLE $outputTableName as SELECT ID, $formatting_geom , NATURE, REGIME FROM ${inputTables.surface_eau}  WHERE the_geom && 'SRID=$sourceSRID;$geomToExtract'::GEOMETRY AND ST_INTERSECTS(the_geom, 'SRID=$sourceSRID;$geomToExtract'::GEOMETRY)".toString())
 
         }
 

--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/BDTopoV3Workflow.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/BDTopoV3Workflow.groovy
@@ -396,8 +396,8 @@ def filterLinkedShapeFiles(def location, float distance, LinkedHashMap inputTabl
             debug "Loading in the H2GIS database $outputTableName"
             outputTableName = "surface_hydrographique"
             h2gis_datasource.execute("""DROP TABLE IF EXISTS $outputTableName ; CREATE TABLE $outputTableName as 
-                SELECT ID, $formatting_geom, NATURE, POS_SOL FROM ${inputTables.surface_hydrographique}  WHERE the_geom && 'SRID=$sourceSRID;$geomToExtract'::GEOMETRY 
-                AND ST_INTERSECTS(the_geom, 'SRID=$sourceSRID;$geomToExtract'::GEOMETRY)""".toString())
+                SELECT ID, $formatting_geom, NATURE, POS_SOL,  PERSISTANC FROM ${inputTables.surface_hydrographique}  WHERE the_geom && 'SRID=$sourceSRID;$geomToExtract'::GEOMETRY 
+                AND ST_INTERSECTS(the_geom, 'SRID=$sourceSRID;$geomToExtract'::GEOMETRY)""")
         }
 
         if (inputTables.zone_de_vegetation) {

--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/InputDataFormatting.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/InputDataFormatting.groovy
@@ -624,7 +624,7 @@ String formatHydroLayer(JdbcDataSource datasource, String water, String zone = "
             if (zone) {
                 datasource.createSpatialIndex(water, "the_geom")
                 query = "select st_intersection(a.the_geom, b.the_geom) as the_geom " +
-                        ", a.ZINDEX, a.ID_SOURCE, a.TYPE " +
+                        ", a.ZINDEX, a.ID_SOURCE, a.TYPE ,  a.REGIME " +
                         " FROM " +
                         "$water AS a, $zone AS b " +
                         "WHERE " +

--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/InputDataLoading.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/InputDataLoading.groovy
@@ -143,7 +143,8 @@ def loadV2(
     String surface_eau = tablesExist.get("surface_eau")
     if (!surface_eau) {
         surface_eau = "surface_eau"
-        datasource.execute("DROP TABLE IF EXISTS $surface_eau;  CREATE TABLE $surface_eau (THE_GEOM geometry(polygon, $srid), ID varchar, NATURE VARCHAR);".toString())
+        datasource.execute("""DROP TABLE IF EXISTS $surface_eau;  
+        CREATE TABLE $surface_eau (THE_GEOM geometry(polygon, $srid), ID varchar, NATURE VARCHAR, REGIME VARCHAR);""")
     }
     String zone_vegetation = tablesExist.get("zone_vegetation")
     if (!zone_vegetation) {
@@ -259,8 +260,9 @@ def loadV2(
     def INPUT_HYDRO = postfix("INPUT_HYDRO")
     datasource.execute("""
             DROP TABLE IF EXISTS $INPUT_HYDRO;
-            CREATE TABLE $INPUT_HYDRO (THE_GEOM geometry, ID_SOURCE varchar(24), ZINDEX integer, TYPE VARCHAR)
-            AS SELECT  ST_FORCE2D(ST_MAKEVALID(a.THE_GEOM)) as the_geom, a.ID, 0, a.NATURE   FROM $surface_eau a, $zone_extended b WHERE a.the_geom && b.the_geom AND ST_INTERSECTS(a.the_geom, b.the_geom);
+            CREATE TABLE $INPUT_HYDRO (THE_GEOM geometry, ID_SOURCE varchar(24), ZINDEX integer, TYPE VARCHAR, REGIME VARCHAR)
+            AS SELECT  ST_FORCE2D(ST_MAKEVALID(a.THE_GEOM)) as the_geom, a.ID, 0, a.NATURE,a.REGIME FROM $surface_eau a, 
+            $zone_extended b WHERE a.the_geom && b.the_geom AND ST_INTERSECTS(a.the_geom, b.the_geom);
             """)
 
     //7. Prepare the Vegetation table (from the layer "ZONE_VEGETATION") that are in the study area (ZONE_EXTENDED)
@@ -450,7 +452,8 @@ Map loadV3(JdbcDataSource datasource,
     if (!surface_hydrographique) {
         surface_hydrographique = "surface_hydrographique"
         datasource.execute("""DROP TABLE IF EXISTS $surface_hydrographique;  
-                CREATE TABLE $surface_hydrographique (THE_GEOM geometry(polygon, $srid), ID varchar, NATURE varchar,POS_SOL integer);""")
+                CREATE TABLE $surface_hydrographique (THE_GEOM geometry(polygon, $srid), 
+                ID varchar, NATURE varchar,POS_SOL integer,REGIME varchar);""")
     }
 
     String zone_de_vegetation = tablesExist.get("zone_de_vegetation")
@@ -603,12 +606,14 @@ Map loadV3(JdbcDataSource datasource,
     def INPUT_HYDRO = postfix("INPUT_HYDRO")
     datasource.execute("""
             DROP TABLE IF EXISTS $INPUT_HYDRO;
-            CREATE TABLE $INPUT_HYDRO (THE_GEOM geometry, ID_SOURCE varchar(24), ZINDEX integer, TYPE varchar)
-            AS SELECT  ST_FORCE2D(ST_MAKEVALID(a.THE_GEOM)) as the_geom, a.ID, 0, a.NATURE FROM $surface_hydrographique a, $zone_extended 
+            CREATE TABLE $INPUT_HYDRO (THE_GEOM geometry, ID_SOURCE varchar(24), ZINDEX integer, TYPE varchar, REGIME varchar)
+            AS SELECT  ST_FORCE2D(ST_MAKEVALID(a.THE_GEOM)) as the_geom, a.ID, 0, a.NATURE,
+            CASE WHEN a.PERSISTANC = 'Permanent' THEN a.PERSISTANC ELSE 'Intermittent' END as REGIME FROM $surface_hydrographique a, $zone_extended 
             b WHERE a.the_geom && b.the_geom AND ST_INTERSECTS(a.the_geom, b.the_geom) and a.POS_SOL>=0
             and a.NATURE not in ('Conduit buse', 'Conduit forcé', 'Marais', 'Glacier névé')
             union all
-            SELECT  ST_FORCE2D(ST_MAKEVALID(a.THE_GEOM)) as the_geom, a.ID, 0, a.NATURE  FROM $terrain_de_sport a, $zone_extended 
+            SELECT  ST_FORCE2D(ST_MAKEVALID(a.THE_GEOM)) as the_geom, a.ID, 0, a.NATURE, 
+            'Permanent' AS REGIME  FROM $terrain_de_sport a, $zone_extended 
             b WHERE a.the_geom && b.the_geom AND ST_INTERSECTS(a.the_geom, b.the_geom) 
             and NATURE = 'Bassin de natation';
             """)

--- a/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/InputDataLoading.groovy
+++ b/bdtopo/src/main/groovy/org/orbisgis/geoclimate/bdtopo/InputDataLoading.groovy
@@ -453,7 +453,7 @@ Map loadV3(JdbcDataSource datasource,
         surface_hydrographique = "surface_hydrographique"
         datasource.execute("""DROP TABLE IF EXISTS $surface_hydrographique;  
                 CREATE TABLE $surface_hydrographique (THE_GEOM geometry(polygon, $srid), 
-                ID varchar, NATURE varchar,POS_SOL integer,REGIME varchar);""")
+                ID varchar, NATURE varchar,POS_SOL integer,PERSISTANC varchar);""")
     }
 
     String zone_de_vegetation = tablesExist.get("zone_de_vegetation")

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
@@ -61,7 +61,7 @@ import static org.h2gis.network.functions.ST_ConnectedComponents.getConnectedCom
  * @return A database table name and the name of the column ID
  */
 String createTSU(JdbcDataSource datasource, String zone,
-                 double area = 1f, String road, String rail, String vegetation,
+                 double area = 1d, String road, String rail, String vegetation,
                  String water, String sea_land_mask, String urban_areas,
                  double surface_vegetation, double surface_hydro, double surface_urban_areas, String prefixName) throws Exception {
 
@@ -130,7 +130,7 @@ String createTSU(JdbcDataSource datasource, String inputTableName, String zone,
         SELECT CAST((row_number() over()) as Integer) as  $COLUMN_ID_NAME,
         ST_BUFFER(ST_BUFFER(the_geom,-0.01, 'quad_segs=2 endcap=flat  join=mitre'),0.01, 'quad_segs=2 endcap=flat join=mitre') AS the_geom FROM 
         ST_EXPLODE('(SELECT ST_POLYGONIZE(ST_UNION(ST_NODE(ST_ACCUM(the_geom)))) AS the_geom 
-                                FROM $inputTableName)')
+                                FROM $inputTableName)') where st_area(the_geom) > $area
         """)
     } else {
         datasource """

--- a/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnits.groovy
@@ -56,7 +56,6 @@ import static org.h2gis.network.functions.ST_ConnectedComponents.getConnectedCom
  * Expressed in geometry unit of the vegetationTable, default 2500
  * @param surface_urban_areas A double value to select the urban  areas.
  * Expressed in geometry unit of the urban_areas table, default 10000
- * @param holeInscribeCircleArea area of the maximum inscribed circle to remove RSU holes
  * @param prefixName A prefix used to name the output table
  *
  * @return A database table name and the name of the column ID
@@ -64,7 +63,7 @@ import static org.h2gis.network.functions.ST_ConnectedComponents.getConnectedCom
 String createTSU(JdbcDataSource datasource, String zone,
                  double area = 1f, String road, String rail, String vegetation,
                  String water, String sea_land_mask, String urban_areas,
-                 double surface_vegetation, double surface_hydro, double surface_urban_areas, double holeInscribeCircleArea, String prefixName) throws Exception {
+                 double surface_vegetation, double surface_hydro, double surface_urban_areas, String prefixName) throws Exception {
 
     def tablesToDrop = []
     try {
@@ -80,7 +79,7 @@ String createTSU(JdbcDataSource datasource, String zone,
 
         tablesToDrop << tsuDataPrepared
         def outputTsuTableName = Geoindicators.SpatialUnits.createTSU(datasource, tsuDataPrepared,zone,
-                area, holeInscribeCircleArea, prefixName)
+                area, prefixName)
         datasource.dropTable(tsuDataPrepared)
 
         datasource.execute("""ALTER TABLE $outputTsuTableName RENAME TO $outputTableName;""")
@@ -107,7 +106,7 @@ String createTSU(JdbcDataSource datasource, String zone,
  * @return A database table name and the name of the column ID
  */
 String createTSU(JdbcDataSource datasource, String inputTableName, String zone,
-                 double area = 1d, double holeInscribeCircleArea = 5000, String prefixName) throws Exception {
+                 double area = 1d, String prefixName) throws Exception {
     def COLUMN_ID_NAME = "id_rsu"
     def BASE_NAME = "tsu"
 
@@ -126,49 +125,13 @@ String createTSU(JdbcDataSource datasource, String inputTableName, String zone,
     if (zone) {
         datasource.createSpatialIndex(zone)
         //Create the polygons from the TSU lines
-        String polygons = postfix("polygons")
-        datasource.execute(""" DROP TABLE IF EXISTS $polygons;
-        CREATE TABLE $polygons as 
+        datasource.execute(""" DROP TABLE IF EXISTS $outputTableName;
+        CREATE TABLE $outputTableName as 
         SELECT CAST((row_number() over()) as Integer) as  $COLUMN_ID_NAME,
         ST_BUFFER(ST_BUFFER(the_geom,-0.01, 'quad_segs=2 endcap=flat  join=mitre'),0.01, 'quad_segs=2 endcap=flat join=mitre') AS the_geom FROM 
         ST_EXPLODE('(SELECT ST_POLYGONIZE(ST_UNION(ST_NODE(ST_ACCUM(the_geom)))) AS the_geom 
                                 FROM $inputTableName)')
         """)
-        datasource.createSpatialIndex(polygons)
-        datasource.createIndex(polygons, COLUMN_ID_NAME)
-        //Get a list of polygons that are in another polygons
-        String inside_polygons = postfix("inside_polygons")
-        datasource.execute("""
-        drop table if exists $inside_polygons;
-        create table $inside_polygons as
-        select a.the_geom, st_area(ST_MAKEPOLYGON(ST_EXTERIORRING(b.the_geom))) as area,  a.$COLUMN_ID_NAME as hole_$COLUMN_ID_NAME, 1 AS inside, b.$COLUMN_ID_NAME as parent_$COLUMN_ID_NAME from $polygons as a, $polygons as b where
-        a.the_geom && b.the_geom and st_intersects(ST_POINTONSURFACE(a.the_geom), ST_MAKEPOLYGON(ST_EXTERIORRING(b.the_geom)))
-        AND a.$COLUMN_ID_NAME <> b.$COLUMN_ID_NAME and st_area(ST_MaximumInscribedCircle(a.the_geom))<5000
-        """)
-        String filter_pols = postfix("filter_pols")
-        datasource.execute("""
-        DROP TABLE IF EXISTS $filter_pols;
-        CREATE TABLE $filter_pols as
-        SELECT distinct on (hole_$COLUMN_ID_NAME) hole_$COLUMN_ID_NAME,
-        parent_$COLUMN_ID_NAME, area, the_geom from  $inside_polygons 
-        order by area asc, hole_$COLUMN_ID_NAME ;""")
-        datasource.createIndex(filter_pols, "parent_$COLUMN_ID_NAME")
-        String tsu_cleaned = postfix("tsu_cleaned")
-        datasource.execute("""
-        DROP TABLE IF EXISTS $tsu_cleaned;
-        CREATE TABLE $tsu_cleaned as 
-        select CAST((row_number() over()) as Integer) as  $COLUMN_ID_NAME, the_geom from ST_EXPLODE('(
-        SELECT st_snaptoself(ST_UNION(ST_ACCUM(st_buffer(the_geom,0.01))),0.01) as the_geom
-        FROM (
-        select the_geom, $COLUMN_ID_NAME from $polygons where $COLUMN_ID_NAME 
-        not in (select distinct  hole_$COLUMN_ID_NAME from $filter_pols)
-        UNION ALL        
-        SELECT ST_ACCUM(THE_GEOM), parent_$COLUMN_ID_NAME AS ID_RSU FROM $filter_pols 
-        group by parent_$COLUMN_ID_NAME) GROUP BY $COLUMN_ID_NAME  )') WHERE ST_DIMENSION(THE_GEOM)=2     
-        """)
-        datasource.execute("ALTER TABLE $tsu_cleaned RENAME TO $outputTableName")
-        datasource.dropTable(polygons, tsu_cleaned, inside_polygons,filter_pols)
-
     } else {
         datasource """
                     DROP TABLE IF EXISTS $outputTableName;
@@ -177,9 +140,7 @@ String createTSU(JdbcDataSource datasource, String inputTableName, String zone,
                         FROM ST_EXPLODE('(
                                 SELECT ST_POLYGONIZE(ST_UNION(ST_NODE(ST_ACCUM(the_geom)))) AS the_geom 
                                 FROM $inputTableName)') where st_area(the_geom) > $area""".toString()
-
     }
-
     debug "Reference spatial units table created"
     return outputTableName
 }
@@ -213,15 +174,15 @@ String prepareTSUData(JdbcDataSource datasource, String zone, String road, Strin
                       double surface_urban_areas,
                       String prefixName = "unified_abstract_model")
         throws Exception {
-    if (surface_vegetation <= 100) {
-        throw new IllegalArgumentException("The surface of vegetation must be greater or equal than 100 m²")
+    if (surface_vegetation < 0) {
+        throw new IllegalArgumentException("The surface of vegetation must be greater or equal than 0 m²")
     }
-    if (surface_hydro <= 100) {
-        throw new IllegalArgumentException("The surface of water must be greater or equal than 100 m²")
+    if (surface_hydro < 0) {
+        throw new IllegalArgumentException("The surface of water must be greater or equal than 0 m²")
     }
 
-    if (surface_urban_areas <= 100) {
-        throw new IllegalArgumentException("The surface of urban areas must be greater or equal than 100 m²")
+    if (surface_urban_areas < 0) {
+        throw new IllegalArgumentException("The surface of urban areas must be greater or equal than 0 m²")
     }
 
     try {

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/DataUtilsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/DataUtilsTests.groovy
@@ -137,7 +137,6 @@ class DataUtilsTests {
     void overlaps2HolesTest3() {
         h2GIS.load("/tmp/geoclimate/urban_areas.fgb","overlaps", true )
         Geoindicators.DataUtils.withinToHoles(h2GIS, "overlaps", "id_urban", "result")
-        h2GIS.save("result", "/tmp/result.fgb", true)
         h2GIS.dropTable("result")
     }
 
@@ -168,7 +167,6 @@ class DataUtilsTests {
         SELECT  3 as  id, 'POLYGON ((99 161, 324 161, 324 58, 99 58, 99 161))'::GEOMETRY THE_GEOM
         """)
         Geoindicators.DataUtils.removeOverlaps(h2GIS, "overlaps", "id", "result")
-        h2GIS.save("result", "/tmp/result.fgb", true)
         assertEquals(2, h2GIS.getRowCount("result"))
         assertTrue( h2GIS.firstRow("select st_area(the_geom) as area_1 from result where id =1").area_1-h2GIS.firstRow("select st_area(the_geom) as area_2 from result where id =2").area_2<0)
         h2GIS.dropTable("result")

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/DataUtilsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/DataUtilsTests.groovy
@@ -134,13 +134,6 @@ class DataUtilsTests {
     }
 
     @Test
-    void overlaps2HolesTest3() {
-        h2GIS.load("/tmp/geoclimate/urban_areas.fgb","overlaps", true )
-        Geoindicators.DataUtils.withinToHoles(h2GIS, "overlaps", "id_urban", "result")
-        h2GIS.dropTable("result")
-    }
-
-    @Test
     void removeOverlapsTest() {
         h2GIS.execute("""
         DROP TABLE IF EXISTS overlaps;

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/DataUtilsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/DataUtilsTests.groovy
@@ -23,11 +23,10 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.io.WKTReader
 import org.orbisgis.data.H2GIS
 import org.orbisgis.geoclimate.Geoindicators
 
+import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.orbisgis.data.H2GIS.open
 
@@ -100,5 +99,78 @@ class DataUtilsTests {
                 "test")
         assert "IDA,IDB,LAB,NAME" == h2GIS.getColumnNames(p).join(",")
         assert 2 == h2GIS.getRowCount(p)
+    }
+
+    @Test
+    void withinToHolesTest() {
+        h2GIS.execute("""
+        DROP TABLE IF EXISTS overlaps;
+        CREATE TABLE overlaps as 
+        SELECT 1 as id, ST_BUFFER(ST_MAKEPOINT(0, 0), 100) AS THE_GEOM, 'geoclimate' as name
+        UNION ALL
+        SELECT CAST((row_number() over()) as Integer) + 1 as  id, THE_GEOM, CONCAT('geoclimate', X) as name FROM ST_EXPLODE('(
+        SELECT ST_BUFFER(ST_MAKEPOINT(0, 0), 10 * X) AS THE_GEOM, X FROM GENERATE_SERIES(1, 4))')
+        """)
+        Geoindicators.DataUtils.withinToHoles(h2GIS, "overlaps", "id", "result")
+        assertEquals(5, h2GIS.getRowCount("result"))
+        h2GIS.dropTable("result")
+    }
+
+    @Test
+    void withinToHolesTest2() {
+        h2GIS.execute("""
+        DROP TABLE IF EXISTS overlaps;
+        CREATE TABLE overlaps as 
+        SELECT 1 as id, ST_BUFFER(ST_MAKEPOINT(0, 0), 100) AS THE_GEOM, 'geoclimate' as name
+        UNION ALL
+        SELECT CAST((row_number() over()) as Integer) + 1 as  id, THE_GEOM, CONCAT('geoclimate', X) as name FROM ST_EXPLODE('(
+        SELECT ST_BUFFER(ST_MAKEPOINT(0, 0), 10 * X) AS THE_GEOM, X FROM GENERATE_SERIES(1, 4))')
+        union all
+        SELECT 10 as id, ST_BUFFER(ST_MAKEPOINT(60, 70), 5) AS THE_GEOM, 'geoclimate_ring' as name
+        """)
+        Geoindicators.DataUtils.withinToHoles(h2GIS, "overlaps", "id", "result")
+        assertEquals(6, h2GIS.getRowCount("result"))
+        h2GIS.dropTable("result")
+    }
+
+    @Test
+    void overlaps2HolesTest3() {
+        h2GIS.load("/tmp/geoclimate/urban_areas.fgb","overlaps", true )
+        Geoindicators.DataUtils.withinToHoles(h2GIS, "overlaps", "id_urban", "result")
+        h2GIS.save("result", "/tmp/result.fgb", true)
+        h2GIS.dropTable("result")
+    }
+
+    @Test
+    void removeOverlapsTest() {
+        h2GIS.execute("""
+        DROP TABLE IF EXISTS overlaps;
+        CREATE TABLE overlaps as 
+        SELECT 1 as id, 'POLYGON ((0 200, 200 200, 200 0, 0 0, 0 200))'::GEOMETRY AS THE_GEOM
+        UNION ALL
+        SELECT  2 as  id, 'POLYGON ((-100 100, 200 100, 200 0, -100 0, -100 100))'::GEOMETRY THE_GEOM
+        """)
+        Geoindicators.DataUtils.removeOverlaps(h2GIS, "overlaps", "id", "result")
+        assertEquals(2, h2GIS.getRowCount("result"))
+        assertTrue( h2GIS.firstRow("select st_area(the_geom) as area_1 from result where id =1").area_1-h2GIS.firstRow("select st_area(the_geom) as area_2 from result where id =2").area_2<0)
+        h2GIS.dropTable("result")
+    }
+
+    @Test
+    void removeOverlapsTest2() {
+        h2GIS.execute("""
+        DROP TABLE IF EXISTS overlaps;
+        CREATE TABLE overlaps as 
+        SELECT 1 as id, 'POLYGON ((0 200, 200 200, 200 0, 0 0, 0 200))'::GEOMETRY AS THE_GEOM
+        UNION ALL
+        SELECT  2 as  id, 'POLYGON ((-100 100, 200 100, 200 0, -100 0, -100 100))'::GEOMETRY THE_GEOM
+        UNION ALL
+        SELECT  3 as  id, 'POLYGON ((99 161, 324 161, 324 58, 99 58, 99 161))'::GEOMETRY THE_GEOM
+        """)
+        Geoindicators.DataUtils.removeOverlaps(h2GIS, "overlaps", "id", "result")
+        h2GIS.save("result", "/tmp/result.fgb", true)
+        assertEquals(2, h2GIS.getRowCount("result"))
+        assertTrue( h2GIS.firstRow("select st_area(the_geom) as area_1 from result where id =1").area_1-h2GIS.firstRow("select st_area(the_geom) as area_2 from result where id =2").area_2<0)
+        h2GIS.dropTable("result")
     }
 }

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/DataUtilsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/DataUtilsTests.groovy
@@ -167,7 +167,7 @@ class DataUtilsTests {
         SELECT  3 as  id, 'POLYGON ((99 161, 324 161, 324 58, 99 58, 99 161))'::GEOMETRY THE_GEOM
         """)
         Geoindicators.DataUtils.removeOverlaps(h2GIS, "overlaps", "id", "result")
-        assertEquals(2, h2GIS.getRowCount("result"))
+        assertEquals(3, h2GIS.getRowCount("result"))
         assertTrue( h2GIS.firstRow("select st_area(the_geom) as area_1 from result where id =1").area_1-h2GIS.firstRow("select st_area(the_geom) as area_2 from result where id =2").area_2<0)
         h2GIS.dropTable("result")
     }

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnitsTests.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/SpatialUnitsTests.groovy
@@ -29,6 +29,7 @@ import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.io.WKTReader
 import org.orbisgis.data.H2GIS
 import org.orbisgis.data.POSTGIS
+import org.orbisgis.data.jdbc.JdbcDataSource
 import org.orbisgis.geoclimate.Geoindicators
 
 import static org.junit.jupiter.api.Assertions.*
@@ -105,15 +106,17 @@ class SpatialUnitsTests {
         h2GIS.load(SpatialUnitsTests.getResource("hydro_test.geojson"), true)
         h2GIS.load(SpatialUnitsTests.getResource("zone_test.geojson"), true)
 
-        def createRSU = Geoindicators.SpatialUnits.createTSU(h2GIS, "zone_test",
+        def createRSU = Geoindicators.SpatialUnits.createTSU(h2GIS, "zone_test",1d,
                 'road_test', 'rail_test',
                 'veget_test', 'hydro_test',
-                "", "", 10000, 2500, 10000,5000, "block")
+                "", "", 10000d, 2500d,
+                10000d, "block")
+
         assert createRSU
 
         assert h2GIS.getSpatialTable(createRSU).save(new File(folder, "rsu.shp").getAbsolutePath(), true)
         def countRows = h2GIS.firstRow "select count(*) as numberOfRows from $createRSU"
-        assert 230 == countRows.numberOfRows
+        assert 237 == countRows.numberOfRows
     }
 
     @Test

--- a/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicatorsTest.groovy
+++ b/geoindicators/src/test/groovy/org/orbisgis/geoclimate/geoindicators/WorkflowGeoIndicatorsTest.groovy
@@ -579,15 +579,15 @@ class WorkflowGeoIndicatorsTest {
     def checkRSUIndicators(def datasource, def rsuIndicatorsTableName) {
         //Check road_fraction > 0
         def countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE ROAD_FRACTION>0".toString())
-        assertEquals(392, countResult.count)
+        assertEquals(405, countResult.count)
 
         //Check building_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE BUILDING_FRACTION>0".toString())
-        assertEquals(128, countResult.count)
+        assertEquals(131, countResult.count)
 
         //Check high_vegetation_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE high_vegetation_fraction>0".toString())
-        assertEquals(59, countResult.count)
+        assertEquals(31, countResult.count)
 
         //Check high_vegetation_water_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE high_vegetation_water_fraction>0".toString())
@@ -603,7 +603,7 @@ class WorkflowGeoIndicatorsTest {
 
         //Check high_vegetation_road_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE high_vegetation_road_fraction>0".toString())
-        assertEquals(55, countResult.count)
+        assertEquals(23, countResult.count)
 
         //Check high_vegetation_impervious_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE high_vegetation_impervious_fraction>0".toString())
@@ -615,7 +615,7 @@ class WorkflowGeoIndicatorsTest {
 
         //Check low_vegetation_fraction > 0.001
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE low_vegetation_fraction>0.001".toString())
-        assertEquals(104, countResult.count)
+        assertEquals(83, countResult.count)
 
         //Check impervious_fraction > 0
         countResult = datasource.firstRow("select count(*) as count from ${rsuIndicatorsTableName} WHERE impervious_fraction>0".toString())

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataFormatting.groovy
@@ -1110,7 +1110,9 @@ String formatUrbanAreas(JdbcDataSource datasource, String urban_areas, String zo
             //Merging urban_areas
             def mergingUrbanAreas = postfix("merging_urban_areas")
             datasource.execute("""
-            CREATE TABLE $mergingUrbanAreas as select CAST((row_number() over()) as Integer) as id_urban,the_geom, type from 
+            CREATE TABLE $mergingUrbanAreas as select CAST((row_number() over()) as Integer) as id_urban,
+            ST_BUFFER(ST_BUFFER(THE_GEOM, 1,'quad_segs=2 endcap=flat'), -1,'quad_segs=2 endcap=flat') AS the_geom, 
+            type from 
             ST_EXPLODE('(SELECT ST_UNION(ST_ACCUM(the_geom)) as the_geom, type from $outputTableName group by type)');
             DROP TABLE IF EXISTS $outputTableName;
             ALTER TABLE  $mergingUrbanAreas RENAME to $outputTableName;

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataLoading.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/InputDataLoading.groovy
@@ -97,7 +97,9 @@ Map extractAndCreateGISLayers(JdbcDataSource datasource, Object zoneToExtract, f
             def keysValues = ["building", "railway", "amenity",
                               "leisure", "highway", "natural",
                               "landuse", "landcover",
-                              "vegetation", "waterway", "area", "aeroway", "area:aeroway", "tourism", "sport", "power"]
+                              "vegetation", "waterway",
+                              "area", "aeroway", "area:aeroway", "tourism", "sport", "power",
+                              "healthcare"]
             query = "[maxsize:1073741824]" + OSMTools.Utilities.buildOSMQueryWithAllData(envelope, keysValues, OSMElement.NODE, OSMElement.WAY, OSMElement.RELATION)
         }
 
@@ -241,7 +243,8 @@ Map createGISLayers(JdbcDataSource datasource, String osmFilePath,
             if(!datasource.isEmpty(impervious)) {
                 //Clean impervious layer to remove highway that doesn't contains a polygon or multipolygon tag
                 //This process is used  to isolate this type of situation : https://www.openstreetmap.org/relation/530964#map=17/48.924457/2.360138
-                datasource.execute("DELETE FROM $impervious where \"highway\" is not null and \"type\"  is null ")
+                datasource.execute("""DELETE FROM $impervious where \"highway\" is not null and (\"type\"  is null
+                and \"area\"!='yes') """)
             }
 
             outputImperviousTableName = postfix("OSM_IMPERVIOUS")

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -835,7 +835,7 @@ def extractProcessingParameters(def processing_parameters) throws Exception {
                                   svfSimplified      : true,
                                   surface_vegetation : 10000f,
                                   surface_hydro      : 2500f,
-                                  surface_urban_areas: 10000f,
+                                  surface_urban_areas: 10f,
                                   snappingTolerance  : 0.01f,
                                   mapOfWeights       : ["sky_view_factor"             : 4,
                                                         "aspect_ratio"                : 3,

--- a/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/geoclimate/osm/WorkflowOSM.groovy
@@ -33,7 +33,6 @@ import org.orbisgis.data.H2GIS
 import org.orbisgis.data.api.dataset.ITable
 import org.orbisgis.data.jdbc.JdbcDataSource
 import org.orbisgis.geoclimate.Geoindicators
-import org.orbisgis.geoclimate.geoindicators.DataUtils
 import org.orbisgis.geoclimate.osmtools.OSMTools
 import org.orbisgis.geoclimate.osmtools.utils.OSMElement
 import org.orbisgis.geoclimate.worldpoptools.WorldPopTools
@@ -837,7 +836,6 @@ def extractProcessingParameters(def processing_parameters) throws Exception {
                                   surface_vegetation : 10000f,
                                   surface_hydro      : 2500f,
                                   surface_urban_areas: 10000f,
-                                  surface_hole_rsu:    5000f,
                                   snappingTolerance  : 0.01f,
                                   mapOfWeights       : ["sky_view_factor"             : 4,
                                                         "aspect_ratio"                : 3,
@@ -851,8 +849,8 @@ def extractProcessingParameters(def processing_parameters) throws Exception {
     defaultParameters.put("rsu_indicators", rsu_indicators_default)
 
     if (processing_parameters) {
-        def distanceP = processing_parameters.distance
-        if (distanceP!=null && distanceP in Number) {
+        Float distanceP = Geoindicators.DataUtils.asFloat(processing_parameters.distance)
+        if (distanceP!=null) {
             defaultParameters.distance = distanceP
         }
 
@@ -890,17 +888,17 @@ def extractProcessingParameters(def processing_parameters) throws Exception {
             if (snappingToleranceP && snappingToleranceP in Number) {
                 rsu_indicators_default.snappingTolerance = (Float) snappingToleranceP
             }
-            def surface_vegetationP = rsu_indicators.surface_vegetation
-            if (surface_vegetationP && surface_vegetationP in Number) {
-                rsu_indicators_default.surface_vegetation = (Float) surface_vegetationP
+            Float surface_vegetationP = Geoindicators.DataUtils.asFloat(rsu_indicators.surface_vegetation)
+            if (surface_vegetationP!=null) {
+                rsu_indicators_default.surface_vegetation =  surface_vegetationP
             }
-            def surface_hydroP = rsu_indicators.surface_hydro
-            if (surface_hydroP && surface_hydroP in Number) {
-                rsu_indicators_default.surface_hydro = (Float) surface_hydroP
+            Float surface_hydroP = Geoindicators.DataUtils.asFloat(rsu_indicators.surface_hydro)
+            if (surface_hydroP!=null) {
+                rsu_indicators_default.surface_hydro = surface_hydroP
             }
-            def surface_urbanAreasP = rsu_indicators.surface_urban_areas
-            if (surface_urbanAreasP && surface_urbanAreasP in Number) {
-                rsu_indicators_default.surface_urban_areas = (Float) surface_urbanAreasP
+            Float surface_urbanAreasP = Geoindicators.DataUtils.asFloat(rsu_indicators.surface_urban_areas)
+            if (surface_urbanAreasP!=null) {
+                rsu_indicators_default.surface_urban_areas = surface_urbanAreasP
             }
 
             def svfSimplifiedP = rsu_indicators.svfSimplified
@@ -911,11 +909,6 @@ def extractProcessingParameters(def processing_parameters) throws Exception {
             if (estimateHeight && estimateHeight in Boolean) {
                 rsu_indicators_default.estimateHeight = estimateHeight
             }
-            def surface_hole_rsuP = rsu_indicators.surface_hole_rsu
-            if (surface_hole_rsuP && surface_hole_rsuP in Number) {
-                rsu_indicators_default.surface_hole_rsu = (Float) surface_hole_rsuP
-            }
-
             def mapOfWeightsP = rsu_indicators.mapOfWeights
             if (mapOfWeightsP && mapOfWeightsP in Map) {
                 Map defaultmapOfWeights = rsu_indicators_default.mapOfWeights

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/imperviousParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/imperviousParams.json
@@ -20,8 +20,6 @@
     "landuse": [
       "railway",
       "construction",
-      "industrial",
-      "commercial",
       "retail"
     ],
     "area:aeroway": [
@@ -61,39 +59,27 @@
         "rest_area"
       ]
     },
-    "industrial": {
-      "landuse": [
-        "railway",
-        "construction",
-        "industrial"
-      ],
+    "platform": {
+      "railway": [
+        "platform"
+      ]
+    },
+    "aeroway": {
       "area:aeroway": [
         "runway"
       ],
       "aeroway": [
         "apron"
-      ],
-      "railway": [
-        "platform"
-      ],
-      "power": [
-        "plant",
-        "substation"
       ]
     },
-    "commercial": {
-      "landuse": [
-        "commercial"
-      ]
-    },
+    "power": {
+    "power": [
+      "plant",
+      "substation"
+    ]},
     "sport": {
       "leisure": [
         "pitch"
-      ]
-    },
-    "residential": {
-      "highway": [
-        "residential"
       ]
     },
     "pedestrian": {

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/roadParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/roadParams.json
@@ -207,12 +207,6 @@
         "living_street"
       ]
     },
-    "roundabout": {
-      "junction": [
-        "roundabout",
-        "circular"
-      ]
-    },
     "secondary": {
       "highway": [
         "secondary"

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/urbanAreasParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/urbanAreasParams.json
@@ -8,7 +8,8 @@
       "construction",
       "military",
       "railway",
-      "farmyard"
+      "farmyard",
+      "religious"
     ],
     "construction": [],
     "amenity": [
@@ -20,6 +21,9 @@
     "power": [
       "plant",
       "substation"
+    ],
+    "healthcare": [
+      "hospital"
     ]
   },
   "columns": [
@@ -28,7 +32,8 @@
     "construction",
     "amenity",
     "building",
-    "power"
+    "power",
+    "healthcare"
   ],
   "type": {
     "education": {
@@ -49,11 +54,6 @@
     "school": {
       "amenity": [
         "school"
-      ]
-    },
-    "construction": {
-      "landuse": [
-        "construction"
       ]
     },
     "commercial": {
@@ -113,6 +113,16 @@
     "farmyard": {
       "landuse": [
         "farmyard"
+      ]
+    },
+    "healthcare": {
+      "healthcare": [
+        "hospital"
+      ]
+    },
+    "religious": {
+      "landuse": [
+        "religious"
       ]
     }
   }

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/vegetParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/vegetParams.json
@@ -21,7 +21,8 @@
       "vineyard",
       "village_green",
       "allotments",
-      "recreation_ground"
+      "recreation_ground",
+      "greenfield"
     ],
     "landcover": [],
     "leisure": [
@@ -78,11 +79,6 @@
         "farmland"
       ]
     },
-    "tree": {
-      "natural": [
-        "tree"
-      ]
-    },
     "wood": {
       "landcover": [
         "trees"
@@ -134,7 +130,8 @@
       ],
       "sport": [
         "soccer",
-        "rugby"
+        "rugby",
+        "horse_racing"
       ]
     },
     "grassland": {
@@ -173,32 +170,6 @@
         "allotments"
       ]
     },
-    "tree_row": {
-      "natural": [
-        "tree_row"
-      ],
-      "landcover": [
-        "tree_row"
-      ],
-      "barrier": [
-        "tree_row"
-      ]
-    },
-    "hedge": {
-      "barrier": [
-        "hedge"
-      ],
-      "natural": [
-        "hedge",
-        "hedge_bank"
-      ],
-      "fence_type": [
-        "hedge"
-      ],
-      "hedge": [
-        "hedge_bank"
-      ]
-    },
     "mangrove": {
       "wetland": [
         "mangrove"
@@ -208,6 +179,9 @@
       "landuse": [
         "orchard"
       ]
+    },
+    "plant_nursery": {
+      "landuse":["plant_nursery"]
     },
     "vineyard": {
       "landuse": [
@@ -246,11 +220,18 @@
     "wetland": {
       "landuse": [
         "wetland"
+      ],
+      "natural": [
+        "wetland"
       ]
+    },
+    "pitch": {
+    "leisure": [
+      "pitch"
+    ]
     }
   },
   "class": {
-    "tree": "high",
     "farmland": "low",
     "wood": "high",
     "forest": "high",
@@ -259,8 +240,6 @@
     "grassland": "low",
     "heath": "low",
     "park": "low",
-    "tree_row": "high",
-    "hedge": "high",
     "meadow": "low",
     "mangrove": "high",
     "orchard": "high",
@@ -269,6 +248,8 @@
     "sugar_cane": "low",
     "garden": "low",
     "marsh": "low",
-    "saltmarsh": "low"
+    "saltmarsh": "low",
+    "wetland": "low",
+    "plant_nursery": "low"
   }
 }

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/vegetParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/vegetParams.json
@@ -20,7 +20,8 @@
       "orchard",
       "vineyard",
       "village_green",
-      "allotments"
+      "allotments",
+      "recreation_ground"
     ],
     "landcover": [],
     "leisure": [
@@ -159,6 +160,9 @@
     "park": {
       "leisure": [
         "park"
+      ],
+      "landuse": [
+        "recreation_ground"
       ]
     },
     "garden": {

--- a/osm/src/main/resources/org/orbisgis/geoclimate/osm/waterParams.json
+++ b/osm/src/main/resources/org/orbisgis/geoclimate/osm/waterParams.json
@@ -9,7 +9,7 @@
       "tidal_channel", "flowline", "canal", "fairway", "rapids", "waterfall"],
     "landuse": [
       "basin",
-      " salt_pond"
+      "salt_pond"
     ]
   },
   "columns": [
@@ -18,6 +18,7 @@
     "seamark:type",
     "water",
     "waterway",
-    "landuse"
+    "landuse",
+    "intermittent"
   ]
 }

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
@@ -293,7 +293,7 @@ class InputDataFormattingTest {
         //def nominatim = org.orbisgis.geoclimate.osmtools.OSMTools.Utilities.getNominatimData(zoneToExtract)
         // zoneToExtract = nominatim.bbox
 
-        zoneToExtract =  [40.70075,-74.03082,40.709732,-74.01897]
+        zoneToExtract =  [53.250836,-9.097881,53.288462,-8.982439]
 
         //zoneToExtract =[51.328681,1.195128,51.331121,1.199162]
         Map extractData = OSM.InputDataLoading.extractAndCreateGISLayers(h2GIS, zoneToExtract)

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataFormattingTest.groovy
@@ -66,14 +66,14 @@ class InputDataFormattingTest {
         assertEquals 44, h2GIS.getTable(extractData.rail).rowCount
         assertEquals 136, h2GIS.getTable(extractData.vegetation).rowCount
         assertEquals 7, h2GIS.getTable(extractData.water).rowCount
-        assertEquals 40, h2GIS.getTable(extractData.impervious).rowCount
+        assertEquals 45, h2GIS.getTable(extractData.impervious).rowCount
         assertEquals 11, h2GIS.getTable(extractData.urban_areas).rowCount
         assertEquals 0, h2GIS.getTable(extractData.coastline).rowCount
 
         //Buildings
         Map buildingLayers = OSM.InputDataFormatting.formatBuildingLayer(h2GIS, extractData.building)
         String building = buildingLayers.building
-        assertNotNull h2GIS.getTable(building).save(new File(folder, "osm_building_formated.shp").absolutePath, true)
+        assertNotNull h2GIS.getTable(building).save(new File(folder, "osm_building_formated.fgb").absolutePath, true)
         assertEquals 1034, h2GIS.getTable(building).rowCount
         assertTrue h2GIS.firstRow("select count(*) as count from ${building} where NB_LEV is null".toString()).count == 0
         assertTrue h2GIS.firstRow("select count(*) as count from ${building} where NB_LEV<0".toString()).count == 0
@@ -84,12 +84,12 @@ class InputDataFormattingTest {
 
         //Format urban areas
         String urbanAreas = OSM.InputDataFormatting.formatUrbanAreas(h2GIS, extractData.urban_areas)
-        assertNotNull h2GIS.getTable(urbanAreas).save(new File(folder, "osm_urban_areas.shp").absolutePath, true)
+        assertNotNull h2GIS.getTable(urbanAreas).save(new File(folder, "osm_urban_areas.fgb").absolutePath, true)
 
         //Improve building type
         buildingLayers = OSM.InputDataFormatting.formatBuildingLayer(h2GIS, extractData.building, null, urbanAreas)
         String buiding_imp = buildingLayers.building
-        assertNotNull h2GIS.getTable(buiding_imp).save(new File(folder, "osm_building_formated_type.shp").absolutePath, true)
+        assertNotNull h2GIS.getTable(buiding_imp).save(new File(folder, "osm_building_formated_type.fgb").absolutePath, true)
         def rows = h2GIS.rows("select type from ${buiding_imp} where id_build=158 or id_build=982".toString())
         assertEquals(2, rows.size())
         assertTrue(rows.type == ['residential', 'undefined'])
@@ -102,7 +102,7 @@ class InputDataFormattingTest {
 
         //Roads
         String road = OSM.InputDataFormatting.formatRoadLayer(h2GIS, extractData.road)
-        assertNotNull h2GIS.getTable(road).save(new File(folder, "osm_road_formated.shp").absolutePath, true)
+        assertNotNull h2GIS.getTable(road).save(new File(folder, "osm_road_formated.fgb").absolutePath, true)
         assertEquals 145, h2GIS.getTable(road).rowCount
         assertTrue h2GIS.firstRow("select count(*) as count from ${road} where WIDTH is null".toString()).count == 0
         assertTrue h2GIS.firstRow("select count(*) as count from ${road} where WIDTH<=0".toString()).count == 0
@@ -111,27 +111,28 @@ class InputDataFormattingTest {
 
         //Rails
         String rails = OSM.InputDataFormatting.formatRailsLayer(h2GIS, extractData.rail)
-        assertNotNull h2GIS.getTable(rails).save(new File(folder, "osm_rails_formated.shp").absolutePath, true)
+        assertNotNull h2GIS.getTable(rails).save(new File(folder, "osm_rails_formated.fgb").absolutePath, true)
         assertEquals 41, h2GIS.getTable(rails).rowCount
         assertTrue h2GIS.firstRow("select count(*) as count from ${rails} where CROSSING IS NOT NULL".toString()).count == 8
 
         //Vegetation
         String vegetation = OSM.InputDataFormatting.formatVegetationLayer(h2GIS, extractData.vegetation)
-        assertNotNull h2GIS.getTable(vegetation).save(new File(folder, "osm_vegetation_formated.shp").absolutePath, true)
+        assertNotNull h2GIS.getTable(vegetation).save(new File(folder, "osm_vegetation_formated.fgb").absolutePath, true)
         assertEquals 137, h2GIS.getTable(vegetation).rowCount
         assertTrue h2GIS.firstRow("select count(*) as count from ${vegetation} where type is null".toString()).count == 0
         assertTrue h2GIS.firstRow("select count(*) as count from ${vegetation} where HEIGHT_CLASS is null".toString()).count == 0
 
         //Hydrography
         String water = OSM.InputDataFormatting.formatWaterLayer(h2GIS, extractData.water)
-        assertNotNull h2GIS.getTable(water).save(new File(folder, "osm_hydro_formated.shp").absolutePath, true)
-        assertEquals 7, h2GIS.getTable(water).rowCount
-        assertTrue h2GIS.firstRow("select count(*) as count from ${water} where type = 'sea'").count == 0
+        assertNotNull h2GIS.getTable(water).save(new File(folder, "osm_hydro_formated.fgb").absolutePath, true)
+        def waterCount = h2GIS.getTable(water).rowCount
+        assertEquals 7, waterCount
+        assertTrue h2GIS.firstRow("select count(*) as count from ${water} where INTERMITTENT is not null").count == waterCount
 
         //Impervious surfaces
         String impervious = OSM.InputDataFormatting.formatImperviousLayer(h2GIS, extractData.impervious)
-        assertNotNull h2GIS.getTable(impervious).save(new File(folder, "osm_impervious_formated.shp").absolutePath, true)
-        assertEquals 39, h2GIS.getTable(impervious).rowCount
+        assertNotNull h2GIS.getTable(impervious).save(new File(folder, "osm_impervious_formated.fgb").absolutePath, true)
+        assertEquals 37, h2GIS.getTable(impervious).rowCount
 
         //Sea/Land mask
         String sea_land_mask = OSM.InputDataFormatting.formatSeaLandMask(h2GIS, extractData.coastline)
@@ -140,7 +141,7 @@ class InputDataFormattingTest {
         //Build traffic data
         String road_traffic = Geoindicators.RoadIndicators.build_road_traffic(h2GIS, road)
 
-        assertNotNull h2GIS.getTable(road_traffic).save(new File(folder, "osm_road_traffic.shp").absolutePath, true)
+        assertNotNull h2GIS.getTable(road_traffic).save(new File(folder, "osm_road_traffic.fgb").absolutePath, true)
         assertEquals 138, h2GIS.getTable(road_traffic).rowCount
         assertTrue h2GIS.firstRow("select count(*) as count from ${road_traffic} where road_type is not null").count == 138
 
@@ -252,12 +253,12 @@ class InputDataFormattingTest {
         assertEquals 44, h2GIS.getTable(extractData.rail).rowCount
         assertEquals 136, h2GIS.getTable(extractData.vegetation).rowCount
         assertEquals 7, h2GIS.getTable(extractData.water).rowCount
-        assertEquals 40, h2GIS.getTable(extractData.impervious).rowCount
+        assertEquals 45, h2GIS.getTable(extractData.impervious).rowCount
 
         //Buildings with estimation state
         Map buildingLayers = OSM.InputDataFormatting.formatBuildingLayer(h2GIS, extractData.building)
         String buildingLayer = buildingLayers.building
-        assertNotNull h2GIS.getTable(buildingLayer).save(new File(folder, "osm_building_formated.shp").absolutePath, true)
+        assertNotNull h2GIS.getTable(buildingLayer).save(new File(folder, "osm_building_formated.fgb").absolutePath, true)
         assertEquals 1034, h2GIS.getTable(buildingLayer).rowCount
         assertTrue h2GIS.firstRow("select count(*) as count from ${buildingLayer} where NB_LEV is null").count == 0
         assertTrue h2GIS.firstRow("select count(*) as count from ${buildingLayer} where NB_LEV<0").count == 0
@@ -288,12 +289,12 @@ class InputDataFormattingTest {
         }
         def h2GIS = H2GIS.open("${file.absolutePath + File.separator}osm_gislayers;AUTO_SERVER=TRUE".toString())
 
-        def zoneToExtract = "Fontainebleau"
+        def zoneToExtract = "Redon"
 
-        //def nominatim = org.orbisgis.geoclimate.osmtools.OSMTools.Utilities.getNominatimData(zoneToExtract)
+        //def nominatim = OSMTools.Utilities.getNominatimData(zoneToExtract)
         // zoneToExtract = nominatim.bbox
 
-        zoneToExtract =  [53.250836,-9.097881,53.288462,-8.982439]
+       zoneToExtract =  [53.242824,-9.103203,53.299902,-8.915749]
 
         //zoneToExtract =[51.328681,1.195128,51.331121,1.199162]
         Map extractData = OSM.InputDataLoading.extractAndCreateGISLayers(h2GIS, zoneToExtract)
@@ -382,7 +383,7 @@ class InputDataFormattingTest {
         Map gISLayers = OSM.InputDataLoading.createGISLayers(h2GIS, "/tmp/map.osm", 2154)
         //Format Roads
         def road = OSM.InputDataFormatting.formatRoadLayer(h2GIS, gISLayers.road)
-        h2GIS.getTable(road).save("/tmp/formated_osm_road.shp", true)
+        h2GIS.getTable(road).save("/tmp/formated_osm_road.fgb", true)
     }
 
     @Test

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataLoadingTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/InputDataLoadingTest.groovy
@@ -65,7 +65,7 @@ class InputDataLoadingTest {
 
         assertEquals 7, h2GIS.getTable(extract.water).rowCount
 
-        assertEquals 40, h2GIS.getTable(extract.impervious).rowCount
+        assertEquals 45, h2GIS.getTable(extract.impervious).rowCount
 
         assertEquals 11, h2GIS.getTable(extract.urban_areas).rowCount
 

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -713,7 +713,6 @@ class WorflowOSMTest extends WorkflowAbstractTest {
 
     @Disabled
     //Use it to test a list of bboxs collect from various user feedback
-    //The
     @Test
     void testLCZBBOXFeedback() {
         String directory = "/tmp/geoclimate"
@@ -725,6 +724,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
         location = [62.027935,129.76294,62.045902,129.80127] //visual validation in a GIS
         location =[40.70075,-74.03082,40.709732,-74.01897] //visual validation in a GIS
         location=[40.70075,-74.01897,40.709732,-74.00712] //visual validation in a GIS
+        location=[53.242824,-9.103203,53.299902,-8.915749] //visual validation in a GIS
 
         def osm_parmeters = [
                 "description" : "Example of configuration file to run the OSM workflow and store the result in a folder",
@@ -742,6 +742,8 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                 "parameters"  :
                         [
                          "rsu_indicators"       : [
+                                 "surface_urban_areas":0,
+                                 //"surface_vegetation":1500,
                                  "indicatorUse": ["LCZ"]
                          ]
                         ]

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorflowOSMTest.groovy
@@ -742,7 +742,7 @@ class WorflowOSMTest extends WorkflowAbstractTest {
                 "parameters"  :
                         [
                          "rsu_indicators"       : [
-                                 "surface_urban_areas":0,
+                                 //"surface_urban_areas":0,
                                  //"surface_vegetation":1500,
                                  "indicatorUse": ["LCZ"]
                          ]

--- a/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorkflowAbstractTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/geoclimate/osm/WorkflowAbstractTest.groovy
@@ -52,7 +52,7 @@ class WorkflowAbstractTest {
         Map spatialUnits = Geoindicators.WorkflowGeoIndicators.createUnitsOfAnalysis(datasource, zone, zone,buildingTableName,
                 roadTableName, railTableName, vegetationTableName,
                 hydrographicTableName, sealandmaskTableName, urban_areas, "", 10000,
-                2500, 10000, 0.01,5000, true, indicatorUse,prefixName)
+                2500, 10000, 0.01, true, indicatorUse,prefixName)
 
         String relationBuildings = spatialUnits.building
         String relationBlocks = spatialUnits.block


### PR DESCRIPTION
This PR improves the RSU segmentation : 

- remove some large RSU defined as paved type in LCZ
- add intermittent water type (#1027)
- add new vegetation tags ie set horse_racing as grass
- add two data utilities first one to remove overlapping polygons, second one to fix some topological issues with holes inside holes
- landuse tags  "railway", "construction", "industrial" are removed from imprevious areas and used only to describe urban areas.
- improve urban_areas construction remove dupliacted geometries (way and relation), remove overlapping geometries
- use the urban_areas geometries to compute the RSU

LCZ before this PR on Galway area

<img width="1336" height="695" alt="Capture d’écran du 2025-09-30 16-42-44" src="https://github.com/user-attachments/assets/39243d54-f48d-4763-a2bb-73ae6efdbb5e" />

LCZ after this PR on Galway area
<img width="1336" height="695" alt="Capture d’écran du 2025-09-30 17-18-29" src="https://github.com/user-attachments/assets/273143da-6887-4cbd-8525-9d6317fc5a3f" />
